### PR TITLE
added better error message for missing labels

### DIFF
--- a/multibootusb
+++ b/multibootusb
@@ -310,6 +310,8 @@ class AppGui(qemu.AppGui, detect_iso.AppGui, update_cfg.AppGui, uninstall_distro
                 for device in context.list_devices(subsystem='block', DEVTYPE='partition'):
                     if device['ID_BUS']=="usb":
                         for disk in psutil.disk_partitions(all=False):
+                            if 'ID_FS_LABEL' not in device:
+                                print("Could not find a label")
                             if disk[0] == device['DEVNAME']:
                                 found.append(device['DEVNAME'])
             except:
@@ -351,7 +353,11 @@ class AppGui(qemu.AppGui, detect_iso.AppGui, update_cfg.AppGui, uninstall_distro
                             selected_usb_device = device['DEVNAME']
                             #selected_usb_device = device['DEVNAME'][:1]
                             selected_usb_uuid = device['ID_FS_UUID']
-                            selected_usb_label = device['ID_FS_LABEL']
+                            try:
+                                selected_usb_label = device['ID_FS_LABEL']
+                            except KeyError as inst:
+                                print "Could not find a label for device " + device['DEVNAME']
+                                raise inst
                             #selected_usb_mount_path = device_props.Get('org.freedesktop.UDisks.Device', "DeviceMountPaths")[0]
                             for disk in psutil.disk_partitions(all=False):
                                 if disk[0] == str(self.ui.comboBox.currentText()):


### PR DESCRIPTION
If we use the linux method and find a device without a label we now will
print an error message and fall back to dbus instead of silently falling
back to dbus.

I am not sure why find_usb also needed a check (to be precise on my system the comparison in line 315 was invalid) but this fixes it.
