### PR TITLE
quote syslinux.cfg path to avoid trouble with spaces

### DIFF
--- a/multibootusb
+++ b/multibootusb
@@ -406,7 +406,7 @@ class AppGui(qemu.AppGui, imager.Imager, QtGui.QDialog, Ui_Dialog):
                                                                            'Edit syslinux.cfg file manually.\n')
             else:
                 try:
-                    subprocess.Popen(editor + " " + sys_cfg_file, shell=True).pid
+                    subprocess.Popen(editor + " '" + sys_cfg_file + "'", shell=True).pid
                 except OSError:
                     QtGui.QMessageBox.warning(self, 'Error...',
                                   'Failed to open syslinux.cfg file.\n'


### PR DESCRIPTION
If the USB disk has a label with spaces inside (for example 
"/run/media/spahan/BOOT DISK/multibootusb/syslinux.cfg") 
it fails to properly open the file if you press "Edit" in the Syslinux panel.

Adding quotes to the path fixes the issue.