### PR TITLE
Fix crash when mount point has whitespace

### DIFF
--- a/scripts/usb.py
+++ b/scripts/usb.py
@@ -194,7 +194,7 @@ class USB():
                                 # Explanation of command used below: 
                                 # http://explainshell.com/explain?cmd=findmnt+-nr+-o+target+-S+%25s
                                 # http://unix.stackexchange.com/questions/34718/is-there-a-command-to-see-where-a-disk-is-mounted/217412#217412
-                                mount_point = str(os.popen('findmnt -nr -o target -S' % usb_disk).read().strip())
+                                mount_point = str(os.popen('findmnt -nr -o target -S %s' % usb_disk).read().strip())
 
                                 try:
                                     label = str(device['ID_FS_LABEL'])

--- a/scripts/usb.py
+++ b/scripts/usb.py
@@ -188,7 +188,14 @@ class USB():
                                 uuid = str(device['ID_FS_UUID'])
                                 file_system = str(device['ID_FS_TYPE'])
 
-                                mount_point = str(os.popen('mount | grep %s | cut -d" " -f3' % usb_disk).read().strip())
+                                # mount_point = str(os.popen('mount | grep %s | cut -d" " -f3' % usb_disk).read().strip())
+
+                                # The above line fails to capture the correct mount point if it contains whitespace.
+                                # Explanation of command used below: 
+                                # http://explainshell.com/explain?cmd=findmnt+-nr+-o+target+-S+%25s
+                                # http://unix.stackexchange.com/questions/34718/is-there-a-command-to-see-where-a-disk-is-mounted/217412#217412
+                                mount_point = str(os.popen('findmnt -nr -o target -S' % usb_disk).read().strip())
+
                                 try:
                                     label = str(device['ID_FS_LABEL'])
                                 except:


### PR DESCRIPTION
I've noticed when I start up the application with my external USB drive connected with the following mount point: 

```
/media/chris/Toshiba Canvio
```

The application would crash saying essentially "No mount point found at `/media/chris/Toshiba`". Then I looked at the source code and quickly noticed that mount points were found by piping the output of `mount` and `cut`ting by a space. So I did some research and found that a better command would be:

```
findmnt -nr -o target -S
```

which returns the only mount point as the output. See [this StackExchange post](http://unix.stackexchange.com/questions/34718/is-there-a-command-to-see-where-a-disk-is-mounted/217412#217412).

Now the application does not crash upon startup. 

Thanks to all those who helped built this awesome application!