### PR TITLE
Unhardcode icon file type in GNU/Linux laucher

### DIFF
--- a/data/multibootusb.desktop
+++ b/data/multibootusb.desktop
@@ -2,7 +2,7 @@
 Type=Application
 Name=multibootusb
 Comment=Install multiple Linux Operating System on USB
-Icon=multibootusb.png
+Icon=multibootusb
 Exec=multibootusb-pkexec
 Categories=System;
 StartupNotify=true


### PR DESCRIPTION
Since the icon already is installed to a location compliant with [freedesktop.org standards](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html) you don't need to specify the full icon path (neither the file type extension) in the launcher. 
The icon will be found anyway.

This facilitates icon theming.
Cf. this [example `.desktop` launcher](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#example) presented in the freedesktop.org documentation.
