### PR TITLE
scripts/usb.py: use device.get() instead of device[''] to handle KeyError

### DIFF
--- a/scripts/usb.py
+++ b/scripts/usb.py
@@ -102,7 +102,7 @@ def list(partition=1, fixed=None):
                                                    ID_FS_USAGE="filesystem", ID_TYPE="disk",
                                                    ID_BUS="usb"):
                     # if device['ID_BUS'] == "usb" and device['DEVTYPE'] == "partition":
-                    if device['ID_BUS'] in ("usb", "scsi") and device['DEVTYPE'] == "partition":
+                    if device.get('ID_BUS') in ("usb", "scsi") and device.get('DEVTYPE') == "partition":
                         # gen.log(device['DEVNAME'])
                         devices.append(str(device['DEVNAME']))
             else:
@@ -205,7 +205,7 @@ def details_udev(usb_disk_part):
                 vendor = 'No_Vendor'
                 model = 'No_Model'
                 label = 'No_Label'
-            elif device['ID_BUS'] in ("usb", "scsi") and device['DEVTYPE'] == "partition":
+            elif device.get('ID_BUS') in ("usb", "scsi") and device.get('DEVTYPE') == "partition":
                 if (device['DEVNAME']) == usb_disk_part:
                     uuid = str(device['ID_FS_UUID'])
                     file_system = str(device['ID_FS_TYPE'])


### PR DESCRIPTION
The devices returned by list_devices() may not always have all the
properties and referencing them raises a KeyError. Use the .get()
interface as suggested by the upstream[0] to avoid such exceptions.

[0] http://pyudev.readthedocs.io/en/latest/guide.html#id6