### PR TITLE
linux: use system pyudev library instead of bundled

### DIFF
--- a/build_pkg
+++ b/build_pkg
@@ -65,7 +65,7 @@ class pkg():
             print("Ensure thta you have python-stdeb package installed!")
             stdcfg = """[DEFAULT]
                       Package: multibootusb
-                      Depends3: python3-pyqt5, parted, util-linux, mtools, python3-dbus, p7zip-full, python3-six
+                      Depends3: python3-pyqt5, parted, util-linux, mtools, python3-dbus, python3-pyudev, p7zip-full, python3-six
                       Build-Depends: python3-all
                       Section: system
                       XS-Python-Version: = 3.5
@@ -88,9 +88,9 @@ class pkg():
                 result = True
         elif self.pkg_name == 'rpm' or self.pkg_name == 'suse' or self.pkg_name == 'mageia':
             if self.pkg_name == 'suse' or self.pkg_name == 'mageia':
-                require = "python3-qt5, parted, util-linux, mtools, python3-dbus, p7zip, p7zip-plugins, python3-six"
+                require = "python3-qt5, parted, util-linux, mtools, python3-dbus, python3-pyudev, p7zip, p7zip-plugins, python3-six"
             else:
-                require = "PyQt5, parted, util-linux, mtools, python3-dbus, p7zip, p7zip-plugins, python3-six"
+                require = "PyQt5, parted, util-linux, mtools, python3-dbus, python3-pyudev, p7zip, p7zip-plugins, python3-six"
             setup_cfg = ("[bdist_rpm]\n"
                          "Group = Applications/System\n"
                          "Vendor = Sundar <feedback.multibootusb@gmail.com>\n"

--- a/scripts/usb.py
+++ b/scripts/usb.py
@@ -92,9 +92,8 @@ def list(partition=1, fixed=None):
     """
     devices = []
     if platform.system() == "Linux":
-        from . import pyudev
+        import pyudev
         import dbus
-
 
         try:
             # pyudev is good enough to detect USB devices on modern Linux machines.
@@ -189,7 +188,7 @@ def details_udev(usb_disk_part):
     Get details of USB partition using udev
     """
     if platform.system() == "Linux":
-        from . import pyudev
+        import pyudev
         """
         Try with PyUdev to get the details of USB disks.
         This is the easiest and reliable method to find USB details.


### PR DESCRIPTION
Take advantage of upstream's bugfixes in pyudev.
(Not removing the bundled pyudev files just yet)