### PR TITLE
Don't check ID_BUS

### DIFF
--- a/multibootusb
+++ b/multibootusb
@@ -49,6 +49,7 @@ def usage():
 def start_gui():
     from scripts import mbusb_gui
     gen.log('Starting multibootusb GUI...')
+    config.gui = True
     if platform.system() == 'Linux':
         if os.getuid() != 0:
             gen.log('\n\nAdmin privilege is required to run multibootusb.\n If you are running from source try '

--- a/scripts/usb.py
+++ b/scripts/usb.py
@@ -100,7 +100,7 @@ def list_devices(partition=1, fixed=False):
 
             if fixed is True:
                 for device in context.list_devices(subsystem='block'):
-                    if device.get('ID_BUS') in ("usb", "scsi", "ata") and device['DEVTYPE'] in ['disk', 'partition']:
+                    if device.get('DEVTYPE') in ['disk', 'partition'] and device.get('ID_PART_TABLE_TYPE'):
                         devices.append(str(device['DEVNAME']))
                         gen.log("\t" + device['DEVNAME'])
             else:


### PR DESCRIPTION
Don't rely on ID_BUS udev item when checking "All devices".
Should fix #110