### PR TITLE
linux: try to use default text editor first

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -33,7 +33,7 @@ imager_status_text = ""
 
 install_size = ""
 
-editors_linux = ["gedit", "kate", "kwrite"]
+editors_linux = ["xdg-open", "gedit", "kate", "kwrite"]
 editors_win = ["notepad++.exe", "notepad.exe"]
 
 imager_usb_disk = []


### PR DESCRIPTION
xdg-open launches the user's default text editor defined 
on the current desktop environment for text/plain mimetype