### PR TITLE
Reapplied upstream PR #26

### DIFF
--- a/scripts/syslinux.py
+++ b/scripts/syslinux.py
@@ -16,8 +16,8 @@ from . import config
 
 extlinux_path = os.path.join(multibootusb_host_dir(), "syslinux", "bin", "extlinux4")
 syslinux_path = os.path.join(multibootusb_host_dir(), "syslinux", "bin", "syslinux4")
-extlinux_fs = ["ext2", "ext3", "ext4", "Btrfs"]
-syslinux_fs = ["vfat", "ntfs", "FAT32", "NTFS"]
+extlinux_fs = ["ext2", "ext3", "ext4", "Btrfs", "ntfs", "NTFS"]
+syslinux_fs = ["vfat", "FAT32"]
 mbr_bin = resource_path(os.path.join("data", "tools", "mbr.bin"))
 
 


### PR DESCRIPTION
Given issues installing syslinux on NTFS, this commit changes the chosen bootloader to extlinux, as per http://www.syslinux.org/archives/2012-December/019151.html