### PR TITLE
Fixing dependency of get_physical_disk_number() on locale setting.

### DIFF
--- a/scripts/gen.py
+++ b/scripts/gen.py
@@ -494,6 +494,24 @@ class MemoryCheck():
         totalMemory = os.popen("free -m").readlines()[1].split()[1]
         return int(totalMemory)
 
+def get_physical_disk_number(usb_disk):
+    """
+    Get the physical disk number as detected ny Windows.
+    :param usb_disk: USB disk (Like F:)
+    :return: Disk number.
+    """
+    assert platform.system() == 'Windows'
+    import wmi
+    c = wmi.WMI()
+    for physical_disk in c.Win32_DiskDrive():
+        for partition in physical_disk.associators("Win32_DiskDriveToDiskPartition"):
+            for logical_disk in partition.associators("Win32_LogicalDiskToPartition"):
+                if logical_disk.Caption == usb_disk:
+                    log("Physical Device Number is %d" % physical_disk.Index)
+                    return physical_disk.Index
+    raise RuntimeError('Failed to obtain device number for drive ' + usb_disk)
+
+
 if __name__ == '__main__':
     log(quote("""Test-string"""))
     log(has_digit("test-string-with-01-digit"))

--- a/scripts/gen.py
+++ b/scripts/gen.py
@@ -503,12 +503,13 @@ def get_physical_disk_number(usb_disk):
     assert platform.system() == 'Windows'
     import wmi
     c = wmi.WMI()
-    for physical_disk in c.Win32_DiskDrive():
-        for partition in physical_disk.associators("Win32_DiskDriveToDiskPartition"):
-            for logical_disk in partition.associators("Win32_LogicalDiskToPartition"):
-                if logical_disk.Caption == usb_disk:
-                    log("Physical Device Number is %d" % physical_disk.Index)
-                    return physical_disk.Index
+    for partition in c.Win32_DiskPartition():
+        logical_disks = partition.associators("Win32_LogicalDiskToPartition")
+        # Here, 'disk' is a windows logical drive rather than a physical drive
+        for disk in logical_disks:
+            if disk.Caption == usb_disk:
+                log("Physical Device Number is %d" % partition.DiskIndex)
+                return partition.DiskIndex
     raise RuntimeError('Failed to obtain device number for drive ' + usb_disk)
 
 

--- a/scripts/qemu.py
+++ b/scripts/qemu.py
@@ -85,10 +85,11 @@ class Qemu(QtWidgets.QMainWindow, Ui_MainWindow):
                     ram = ""
 
                 if platform.system() == "Windows":
-                    disk_number = self.get_physical_disk_number(qemu_usb_disk)
+                    disk_number = get_physical_disk_number(qemu_usb_disk)
                     parent_dir = os.getcwd()
                     os.chdir(resource_path(os.path.join("data", "tools", "qemu")))
-                    cmd = quote(qemu) + ' -L . -boot c' + ram + ' -hda //./PhysicalDrive' + disk_number
+                    cmd = quote(qemu) + ' -L . -boot c' + ram \
+                          + ' -hda //./PhysicalDrive' + str(disk_number)
 
                     try:
                         log("Executing ==>  " + cmd)
@@ -156,21 +157,3 @@ class Qemu(QtWidgets.QMainWindow, Ui_MainWindow):
 
         return qemu
 
-    @staticmethod
-    def get_physical_disk_number(usb_disk):
-        """
-        Get the physical disk number as detected ny Windows.
-        :param usb_disk: USB disk (Like F:)
-        :return: Disk number.
-        """
-        import wmi
-        c = wmi.WMI()
-        for physical_disk in c.Win32_DiskDrive():
-            for partition in physical_disk.associators("Win32_DiskDriveToDiskPartition"):
-                for logical_disk in partition.associators("Win32_LogicalDiskToPartition"):
-                    if logical_disk.Caption == usb_disk:
-#                         log physical_disk.Caption
-#                         log partition.Caption
-#                         log logical_disk.Caption
-                        log("Physical Device Number is " + partition.Caption[6:-14])
-                        return str(partition.Caption[6:-14])

--- a/scripts/syslinux.py
+++ b/scripts/syslinux.py
@@ -39,7 +39,6 @@ def gpt_part_table(usb_disk):
         elif b'gpt' in _cmd_out:
             return True
     elif platform.system() == 'Windows':
-        win_usb_disk_no = str(usb.get_physical_disk_number(config.usb_disk))
         if config.usb_gpt is True:
             return True
         elif config.usb_gpt is False:
@@ -107,10 +106,10 @@ def syslinux_default(usb_disk):
     if platform.system() == 'Linux':
         mbr_install_cmd = 'dd bs=440 count=1 conv=notrunc if=' + mbr_bin + ' of=' + usb_disk[:-1]
     else:
-        win_usb_disk_no = str(usb.get_physical_disk_number(config.usb_disk))
+        win_usb_disk_no = get_physical_disk_number(config.usb_disk)
         _windd = resource_path(os.path.join("data", "tools", "dd", "dd.exe"))
         _input = "if=" + mbr_bin
-        _output = 'of=\\\.\\physicaldrive' + win_usb_disk_no
+        _output = 'of=\\\.\\physicaldrive' + str(win_usb_disk_no)
         mbr_install_cmd = _windd + ' ' + _input + ' ' + _output + ' count=1'
 
     if usb_fs in extlinux_fs:

--- a/scripts/usb.py
+++ b/scripts/usb.py
@@ -365,13 +365,13 @@ def gpt_device(dev_name):
         startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
         diskpart_cmd = 'wmic partition get name, type'
         # We have to check using byte code else it crashes when system language is other than English
-        dev_no = get_physical_disk_number(dev_name).encode()
+        dev_no = gen.get_physical_disk_number(dev_name)
         cmd_out = subprocess.check_output(diskpart_cmd, subprocess.SW_HIDE, startupinfo=startupinfo)
         gen.log(cmd_out)
         cmd_spt = cmd_out.split(b'\r')
         for line in cmd_spt:
             # line = line('utf-8')
-            if b'#' + dev_no + b',' in line:
+            if b'#%d,' % dev_no in line:
                 if b'GPT' not in line:
                     config.usb_gpt = False
                     gen.log('Device ' + dev_name + ' is a MBR disk...')
@@ -470,22 +470,6 @@ def details(usb_disk_part):
         details = win_disk_details(usb_disk_part)
 
     return details
-
-
-def get_physical_disk_number(usb_disk):
-    """
-    Get the physical disk number as detected ny Windows.
-    :param usb_disk: USB disk (Like F:)
-    :return: Disk number.
-    """
-    import wmi
-    c = wmi.WMI()
-    for physical_disk in c.Win32_DiskDrive():
-        for partition in physical_disk.associators("Win32_DiskDriveToDiskPartition"):
-            for logical_disk in partition.associators("Win32_LogicalDiskToPartition"):
-                if logical_disk.Caption == usb_disk:
-                    # gen.log("Physical Device Number is " + partition.Caption[6:-14])
-                    return str(partition.Caption[6:-14])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
get_physical_disk_number() can fail on non-English version of Windows because the value of partition.Caption obtained via wmi.WMI().Win32_DiskDrive() is locale dependent.
