### PR TITLE
Allow setting of build related paths in an external file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ text.py
 .pydevproject
 .settings*
 .directory
+
+# External path setting file for build_pkg script.
+build_pkg_path.json

--- a/build_pkg
+++ b/build_pkg
@@ -21,14 +21,29 @@ import subprocess
 import sys
 import platform
 import re
+import json
+
+def load_path_setting(src_json_file):
+    if not os.path.exists(src_json_file):
+        return None
+    with open(src_json_file) as f:
+        platform2settings = json.load(f)
+    return platform2settings[platform.system()]
 
 
 ####################################################################################################
-#  Change the below variables to suit your needs.
+#  Change the below variables to suit your needs
+#  or create 'build_pkg_path.json' file.
 if platform.system() == "Windows":
-    pyinstaller_path = 'D:\multibootusb\pyinstaller\pyinstaller.py'
-    release_dir = 'D:\\multibootusb\\release'
-    nsis = '\"C:\\Program Files (x86)\\NSIS\\makensis.exe\"'
+    d = load_path_setting('build_pkg_path.json')
+    if d is None:
+        d = {
+            'pyinstaller_path': 'D:\multibootusb\pyinstaller\pyinstaller.py',
+            'release_dir':      'D:\\multibootusb\\release',
+            'nsis': '\"C:\\Program Files (x86)\\NSIS\\makensis.exe\"'
+            }
+    pyinstaller_path, release_dir, nsis = [
+        d[x] for x in ['pyinstaller_path', 'release_dir', 'nsis']]
 else:
     from os.path import expanduser
     home = expanduser("~")
@@ -37,6 +52,20 @@ else:
     release_dir = "/media/sundar/Data/multibootusb/release"
     debian_bin_path = '/usr/bin/multibootusb'
     rpm_bin_path = '/usr/local/bin/multibootusb'
+
+    # Let's keep the following block disabled until somebody tests it out.
+    #
+    # d = load_path_setting('build_pkg_path.json')
+    # if d is None:
+    #    d = {
+    #        'pyinstaller_path': '/media/sundar/Data/multibootusb/pyinstaller/pyinstaller.py',
+    #        'release_dir': '/media/sundar/Data/multibootusb/release',
+    #        'debian_bin_path': '/usr/bin/multibootusb',
+    #        'rpm_bin_path': '/usr/local/bin/multibootusb'
+    #        }
+    # pyinstaller_path, release_dir, debian_bin_path, rpm_bin_path = [
+    #     d[x] for x in ['pyinstaller_path', 'release_dir',
+    #                    'debian_bin_path', 'rpm_bin_path']]
 
 sourceforge_release_path = "multibootusb@frs.sourceforge.net:/home/frs/project/multibootusb/"
 ####################################################################################################

--- a/build_pkg_path.json.template
+++ b/build_pkg_path.json.template
@@ -1,0 +1,13 @@
+{
+  "Windows": 
+    {"pyinstaller_path": "C:\\Users\\shinj\\AppData\\Local\\Programs\\Python\\Python36\\Scripts\\pyinstaller-script.py",
+     "release_dir": "C:\\Users\\shinj\\Documents\\src\\multibootusb\\release",
+     "nsis": "\"C:\\Program Files (x86)\\NSIS\\makensis.exe\""
+    },
+  "Linux":
+    {"pyinstaller_path": "/media/sundar/Data/multibootusb/pyinstaller/pyinstaller.py",
+     "release_dir": "/media/sundar/Data/multibootusb/release",
+     "debian_bin_path": "/usr/bin/multibootusb",
+     "rpm_bin_path": "/usr/local/bin/multibootusb"
+    }
+}


### PR DESCRIPTION
Allow paths such as 'pyinstaller_dir' or 'release_dir' to be configured outside of 'build_pkg' script so that conflict on the path setting code block can be avoided. Currently paths are read out of 'build_pkg_path.json' file. If the file is not present, setting in the script will be used.
 