### PR TITLE
Allow one pass execution of multi patterned file extraction.

### DIFF
--- a/scripts/_7zip.py
+++ b/scripts/_7zip.py
@@ -44,10 +44,16 @@ def extract_iso(src, dst, pattern=None, suppress_out=True):
     if not os.path.exists(dst):
         os.makedirs(dst, exist_ok=True)
 
+    src = gen.quote(src)
+    dst = gen.quote(dst)
     if pattern is None:
-        _cmd = _7zip + cli_option + ' x -y -o' + gen.quote(dst) + ' ' + gen.quote(src) + suppress_out
+        _cmd = _7zip + cli_option + ' x -y -o' + dst + ' ' + src + suppress_out
     else:
-        _cmd = _7zip + cli_option + ' x -y ' + gen.quote(src) + ' -o' + dst + ' ' + gen.quote(pattern) + ' -r' + suppress_out
+        if type(pattern) is str:
+            pattern = [pattern]
+        pattern_str = ' '.join(gen.quote(s) for s in pattern)
+        _cmd = _7zip + cli_option + ' x -y ' + src + \
+               ' -o' + dst + ' ' + pattern_str + ' -r' + suppress_out
     gen.log('Executing ==> ' + _cmd)
 
     config.status_text = 'Status: Extracting ' + os.path.basename(src).strip()
@@ -117,6 +123,25 @@ def test_iso(iso_link, suppress_out=True):
 
     return bool(rc in [0, 1])
 
+def test_extraction():
+    import shutil
+
+    src = 'c:/Users/shinj/Downloads/clonezilla-live-2.5.2-31-amd64.iso'
+    tmp_dir = 'c:/Users/shinj/Documents/tmp'
+    for subdir, pattern in [
+            ('single_string', 'EFI/'),
+            ('single_list', ['EFI/']),
+            ('multi', ['EFI/', 'syslinux/']),
+            ('all', None) ]:
+        dest_dir = os.path.join(tmp_dir, subdir)
+        if os.path.exists(dest_dir):
+            shutil.rmtree(dest_dir)
+        os.mkdir(dest_dir)
+        args = [src, dest_dir]
+        if pattern is not None:
+            args.append(pattern)
+        print ('Calling extract_iso(%s)' % args)
+        extract_iso(*args)
 
 if __name__ == '__main__':
     # slitaz-4.0.iso

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -47,11 +47,8 @@ def install_distro():
     if config.distro == "opensuse":
         iso.iso_extract_file(config.image_path, install_dir, 'boot')
         config.status_text = "Copying ISO..."
-        if platform.system() == "Windows":
-            subprocess.call(["xcopy", config.image_path, usb_mount], shell=True)  # Have to use xcopy as python file copy is dead slow.
-        elif platform.system() == "Linux":
-            log("Copying " + config.image_path + " to " + usb_mount)
-            shutil.copy(config.image_path, usb_mount)
+        log("Copying " + config.image_path + " to " + usb_mount)
+        copy_iso(config.image_path, usb_mount)
     elif config.distro == "Windows" or config.distro == 'pc-unlocker'\
             or config.distro == 'pc-tool' or config.distro == 'grub2only':
         log("Extracting iso to " + usb_mount)
@@ -62,8 +59,8 @@ def install_distro():
             shutil.rmtree(os.path.join(usb_mount, 'trk3'))
         shutil.move(os.path.join(install_dir, 'trk3'), os.path.join(usb_mount))
     elif config.distro == "ipfire":
-        iso.iso_extract_file(config.image_path, usb_mount, '*.tlz')
-        iso.iso_extract_file(config.image_path, usb_mount, 'distro.img')
+        iso.iso_extract_file(config.image_path, usb_mount,
+                             ['*.tlz', 'distro.img'])
         iso.iso_extract_file(config.image_path, install_dir, 'boot')
     elif config.distro == "zenwalk":
         config.status_text = "Copying ISO..."
@@ -71,14 +68,11 @@ def install_distro():
         copy_iso(config.image_path, install_dir)
     elif config.distro == "salix-live":
         # iso.iso_extract_file(config.image_path, install_dir, "boot")
-        iso.iso_extract_file(config.image_path, install_dir, '*syslinux')
-        iso.iso_extract_file(config.image_path, install_dir, '*menus')
-        iso.iso_extract_file(config.image_path, install_dir, '*vmlinuz')
-        iso.iso_extract_file(config.image_path, install_dir, '*initrd*')
-        iso.iso_extract_file(config.image_path, usb_mount, '*modules')
-        iso.iso_extract_file(config.image_path, usb_mount, '*packages')
-        iso.iso_extract_file(config.image_path, usb_mount, '*optional')
-        iso.iso_extract_file(config.image_path, usb_mount, '*liveboot')
+        iso.iso_extract_file(config.image_path, install_dir,
+                             ['*syslinux', '*menus', '*vmlinuz', '*initrd*'])
+        iso.iso_extract_file(config.image_path, usb_mount,
+                             ['*modules', '*packages', '*optional',
+                              '*liveboot'])
         #iso.iso_extract_full(config.image_path, usb_mount)
         config.status_text = "Copying ISO..."
         copy_iso(config.image_path, install_dir)
@@ -147,7 +141,11 @@ def copy_iso(src, dst):
     :return:
     """
     if platform.system() == "Windows":
-        subprocess.call("xcopy " + src + " " + dst, shell=True)
+        # Note that xcopy asks if the target is a file or a directory when
+        # source filename (or dest filename) contains space(s) and the target
+        # does not exist.
+        assert os.path.exist(dst)
+        subprocess.call(['xcopy', '/Y', src, dst], shell=True)
     elif platform.system() == "Linux":
         shutil.copy(src, dst)
 

--- a/scripts/iso.py
+++ b/scripts/iso.py
@@ -85,13 +85,11 @@ def isolinux_bin_dir(iso_link):
     """
     if os.path.exists(iso_link):
         bin_dir = False
-        iso_file_list = _7zip.list_iso(iso_link)
-        if any("isolinux.bin" in s.lower() for s in iso_file_list):
-            for f in iso_file_list:
-                if 'isolinux.bin' in f.lower():
-                    if 'efi' not in f.lower():  # Certain distros place their isolinux.bin in to /EFI/BOOT director and we don't want to include them
-                        bin_dir = os.path.dirname(f)
-                        break
+        for f in _7zip.list_iso(iso_link):
+            if 'isolinux.bin' in f.lower():
+                if 'efi' not in f.lower():  # Certain distros place their isolinux.bin in to /EFI/BOOT director and we don't want to include them
+                    bin_dir = os.path.dirname(f)
+                    break
 
         return bin_dir
 


### PR DESCRIPTION
Allow one pass execution of multi patterned file extraction.
Make use of copy_iso() function and add '/Y' to xcopy command and an assert to prevent a hang.
Remove redundant membership check before iterating over the members.
