### PR TITLE
More fixes on syslinux installation and loopback.cfg generation.

### DIFF
--- a/scripts/grub.py
+++ b/scripts/grub.py
@@ -376,8 +376,6 @@ def iso2grub2(install_dir, loopback_cfg_path, wrote_custom_cfg):
                 for keyword, value in re.findall(
                         r'^\s*(kernel|linux|initrd|append)[= ](.*)$',
                         matching_block, re.I|re.MULTILINE):
-                    # Ensure that we do not have caps label in the menuentry.
-                    value = value.replace(keyword.upper(), '') # Essencial?
                     kw = keyword.lower()
                     if kw in ['kernel', 'linux']:
                         if linux_line:

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -132,7 +132,7 @@ def copy_iso(src, dst):
         # Note that xcopy asks if the target is a file or a directory when
         # source filename (or dest filename) contains space(s) and the target
         # does not exist.
-        assert os.path.exist(dst)
+        assert os.path.exists(dst)
         subprocess.call(['xcopy', '/Y', src, dst], shell=True)
     elif platform.system() == "Linux":
         shutil.copy(src, dst)


### PR DESCRIPTION
Tested with following distributions. At least one menu item booted via grub successfully with the exception of dban. Dban hang during boot and I'm not brave enough to try further.

- antergos-18.3-x86_64
- debian-live-9.4.0-amd64-cinnamon
- dban-2.3.0_i586
- Fedora-Workstation-Live-x86_64-27-1.6
- kali-linux-light-2018.1-amd64
- MorpheusArchLinux-20-01-17-2017.01.20-dual
- kubuntu-18.04-beta1-desktop-amd64
- ubuntu-17.10.1-desktop-amd64
- linuxmint-18.3-kde-64bit
- clonezilla-live-2.5.2-31-amd64
