### PR TITLE
Fix tweaking of 'initrd=...' line keyed on 'initrd' because 'initrd'

### DIFF
--- a/scripts/update_cfg_file.py
+++ b/scripts/update_cfg_file.py
@@ -232,8 +232,10 @@ def update_distro_cfg_files(iso_link, usb_disk, distro, persistence=0):
                 elif distro == "salix-live":
                     string = re.sub(r'iso_path', '/multibootusb/' + iso_basename(iso_link) + '/' + iso_name(iso_link),
                                     string)
-                    string = re.sub(r'initrd', 'fromiso=/multibootusb/' + iso_basename(iso_link) + '/' +
-                                    iso_name(iso_link) + ' initrd', string)
+                    string = re.sub(r'initrd=',
+                                    'fromiso=/multibootusb/'
+                                    + iso_basename(iso_link) + '/'
+                                    + iso_name(iso_link) + ' initrd=', string)
                 elif distro == 'alt-linux':
                     string = re.sub(r':cdrom', ':disk', string)
                 elif distro == 'fsecure':


### PR DESCRIPTION
part in 'initrd.img' gets affected.
Now salixlive-xfce-14.2.1 boots but sadly /init fails to mount live media. It seems fromiso= parameter is not honored anymore.
