### PR TITLE
Fix regression introduced by 8ea5932bdcd706d7ca4c8b44aa7b0a424daec59d.

### DIFF
--- a/scripts/iso.py
+++ b/scripts/iso.py
@@ -209,6 +209,10 @@ def iso_file_path(iso_link, file_name):
 
     return file_path
 
+def get_file_list(iso_link, predicate):
+    # Note that unlike iso_file_path(), only the basename is checked.
+    return [f for f in _7zip.list_iso(iso_link) if predicate(f)]
+
 if __name__ == '__main__':
     #iso_path = '../../../DISTROS/2016/debian-live-8.3.0-amd64-lxde-desktop.iso'
     iso_path = '../../../DISTROS/2015/super_grub2_disk_hybrid_2.02s3.iso'


### PR DESCRIPTION
With the change in the commit, loopback.cfg got regenerated at the
location of file determined by scanning iso tree. If no loopback.cfg was
available, new one got generated at the distribution tree root. In ether
case, loopback.cfg was always chosen for booting.
Now, if no loopback.cfg is found, grub.cfg is sought. It is only in the
case where neither is found that loopback.cfg gets generated and used.