### PR TITLE
Detect running 7zip on a currupted iso as well as the lack of 7z

### DIFF
--- a/scripts/_7zip.py
+++ b/scripts/_7zip.py
@@ -61,7 +61,7 @@ def extract_iso(src, dst, pattern=None, suppress_out=True):
         subprocess.call(_cmd, stdin=devnull, stdout=devnull, stderr=devnull, shell=True)
 
 
-def list_iso(iso_link, suppress_out=True):
+def list_iso(iso_link, suppress_out=True, expose_exception=False):
     """
     List the content of ISO files. It does'nt work with non 'utf' characters (simply ignores them).
     :param iso_link:Path to ISO link
@@ -85,6 +85,8 @@ def list_iso(iso_link, suppress_out=True):
                                                shell=True).decode('utf-8', 'ignore').splitlines()
         except Exception as e:
             gen.log(e)
+            if expose_exception:
+                raise
             _cmd_out = ''
         for line in _cmd_out:
             if '...' in line:

--- a/scripts/distro.py
+++ b/scripts/distro.py
@@ -15,7 +15,7 @@ from .gen import *
 from . import _7zip
 
 
-def distro(iso_cfg_ext_dir, iso_link):
+def distro(iso_cfg_ext_dir, iso_link, expose_exception=False):
     """
     Detect if distro is supported by multibootusb.
     :param iso_cfg_ext_dir: Directory where *.cfg files are extracted.
@@ -23,7 +23,7 @@ def distro(iso_cfg_ext_dir, iso_link):
     """
 #     iso9660fs = ISO9660(iso_link)
 #     iso_file_list = iso9660fs.readDir("/")
-    iso_file_list = _7zip.list_iso(iso_link)
+    iso_file_list = _7zip.list_iso(iso_link, expose_exception=expose_exception)
     if platform.system() == "Linux" or platform.system() == "Windows":
         for path, subdirs, files in os.walk(iso_cfg_ext_dir):
             for name in files:
@@ -146,7 +146,7 @@ def distro(iso_cfg_ext_dir, iso_link):
                         elif re.search(r'BOOT_IMAGE=insert', string, re.I):
                             return 'insert'
 
-        distro = detect_iso_from_file_list(iso_link)
+        distro = detect_iso_from_file_list(iso_link, iso_file_list)
 
         if distro:
             return distro
@@ -166,13 +166,12 @@ def distro(iso_cfg_ext_dir, iso_link):
             return None
 
 
-def detect_iso_from_file_list(iso_link):
+def detect_iso_from_file_list(iso_link, iso_file_list):
     """
     Fallback detection script from the content of an ISO.
     :return: supported distro as string
     """
     if os.path.exists(iso_link):
-        iso_file_list = _7zip.list_iso(iso_link)
         if any("sources" in s.lower() for s in iso_file_list) and any("boot.wim" in s.lower() for s in iso_file_list):
             return "Windows"
         elif any("config.isoclient" in s.lower() for s in iso_file_list):


### PR DESCRIPTION
executable.
Remove repeated call to _7zip.list_iso(iso_link)
Adjusted line breaking to fit within 80 columns.