### PR TITLE
Fix module name typo that gets triggered by overwriting installation of

### DIFF
--- a/scripts/install.py
+++ b/scripts/install.py
@@ -220,7 +220,7 @@ class DirectoryRelocator:
             src = os.path.join(self.src_dir, dir_name)
             dst = os.path.join(self.dst_dir, dir_name)
             if os.path.exists(dst):
-                os.rmtree(dst)
+                shutil.rmtree(dst)
             shutil.move(src, dst)
 
 if __name__ == '__main__':


### PR DESCRIPTION
distros that have some dirs relocated to the root dir.
This error does not get triggered in normal situation. It manifests if installation is tried after unsuccessful uninstallation.
