### PR TITLE
* Fix distro detection going out of sync after uninstalling a distro

### DIFF
--- a/scripts/mbusb_gui.py
+++ b/scripts/mbusb_gui.py
@@ -453,16 +453,23 @@ Are you SURE you want to enable it?",
             QtWidgets.QMessageBox.information(self, 'No selection.', 'Please select a distro from the list.')
             self.ui_enable_controls()
         else:
-            config.uninstall_distro_dir_name = str(self.ui.installed_distros.currentItem().text()).strip()
-            reply = QtWidgets.QMessageBox.question(self, "Review selection...",
-                                                   "Are you sure to uninstall " + config.uninstall_distro_dir_name,
-                                                   QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
-                                                   QtWidgets.QMessageBox.No)
+            config.uninstall_distro_dir_name = str(
+                self.ui.installed_distros.currentItem().text()).strip()
+            reply = QtWidgets.QMessageBox.question(
+                self, "Review selection...",
+                "Are you sure to uninstall " + config.uninstall_distro_dir_name,
+                QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
+                QtWidgets.QMessageBox.No)
 
             if reply == QtWidgets.QMessageBox.Yes:
-                if not os.path.exists(os.path.join(config.usb_mount, 'multibootusb', config.uninstall_distro_dir_name)):
-                    log("Distro install directory not found. Just updating syslinux.cfg file.")
-                    update_sys_cfg_file()
+                if not os.path.exists(
+                        os.path.join(config.usb_mount, 'multibootusb',
+                                     config.uninstall_distro_dir_name)):
+                    log("Distro install directory not found. "
+                        "Just updating syslinux.cfg and grub.cfg.")
+                    update_sys_cfg_file(config.uninstall_distro_dir_name)
+                    update_grub_cfg_file(config.uninstall_distro_dir_name)
+                    self.uninstall_sys_file_update()
                     # self.uninstall.update_sys_cfg_file()
                     self.ui_enable_controls()
                 else:
@@ -475,7 +482,10 @@ Are you SURE you want to enable it?",
         Function to remove and update uninstall distro text.
         :return:
         """
-        update_sys_cfg_file()
+
+        # This function is already called from 'do_uninstall_distro()'
+        # update_sys_cfg_file(config.uninstall_distro_dir_name)
+
         self.update_list_box(config.usb_mount)
         if sys.platform.startswith("linux"):
             self.ui.statusbar.showMessage("Status: Sync in progress...")


### PR DESCRIPTION
because config.distro gets overwritten during uninstallation.
Here is a way to reproduce the issue.
1. install an arch variant.
2. select a debian variant iso.
3. uninstall the arch variant.
4. click 'install'
5. mbusb tries to install the debian variant assuming 'arch'.
* Fix missed call to update_list_box() when performing config-files-only
uninstallation, which happens because distro dir is already gone.
* Fix missed update of grub.cfg when performing config-files-only
uninstallation.
* Fix multiple calls to delete_frm_file_list() when uninstalling
'windows', 'alpine' and 'generic'.
* Fix multiple calls to update_sys_cfg_file() when uninstalling a distro.
* Escape distro name when using it within regular expressions.
* Adjust line breaking to fit 80 cols.