### PR TITLE
Fix bug in a ConfigTweaker method & Add CentOS 7 Installer DVD support

### DIFF
--- a/scripts/distro.py
+++ b/scripts/distro.py
@@ -65,6 +65,9 @@ def distro(iso_cfg_ext_dir, iso_link, expose_exception=False):
                             return "solydx"
                         elif re.search(r'knoppix', string, re.I):
                             return "knoppix"
+                        elif re.search(r'root=live:CDLABEL=CentOS',
+                                        string, re.I):
+                            return 'centos' # centos-live
                         elif re.search(r'root=live:CDLABEL=', string, re.I) or re.search(r'root=live:LABEL=', string, re.I):
                             return "fedora"
                         elif re.search(r'redcore', string, re.I):
@@ -115,6 +118,8 @@ def distro(iso_cfg_ext_dir, iso_link, expose_exception=False):
                             return "zenwalk"
                         elif re.search(r'ubuntu server', string, re.I):
                             return "ubuntu-server"
+                        elif re.search(r'Install CentOS', string, re.I):
+                            return "centos-install"
                         elif re.search(r'CentOS', string, re.I):
                             return "centos"
                         elif re.search(r'Trinity Rescue Kit', string, re.I):

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -27,20 +27,30 @@ def install_distro():
     :return:
     """
     usb_mount = config.usb_mount
-    install_dir = os.path.join(config.usb_mount, "multibootusb", iso_basename(config.image_path))
+    install_dir = os.path.join(config.usb_mount, "multibootusb",
+                               iso_basename(config.image_path))
 
     if not os.path.exists(os.path.join(usb_mount, "multibootusb")):
         log("Copying multibootusb directory to " + usb_mount)
-        shutil.copytree(resource_path(os.path.join("data", "tools", "multibootusb")),
-                        os.path.join(config.usb_mount, "multibootusb"))
+        shutil.copytree(
+            resource_path(os.path.join("data", "tools", "multibootusb")),
+            os.path.join(config.usb_mount, "multibootusb"))
 
     if not os.path.exists(install_dir):
+        _iso_file_list = iso.iso_file_list(config.image_path)
         os.makedirs(install_dir)
         with open(os.path.join(install_dir, "multibootusb.cfg"), "w") as f:
             f.write(config.distro)
         with open(os.path.join(install_dir, "iso_file_list.cfg"), 'w') as f:
-            for file_path in iso.iso_file_list(config.image_path):
+            for file_path in _iso_file_list:
                 f.write(file_path + "\n")
+    else:
+        # This path is usually not taken.
+        with open(os.path.join(install_dir, "multibootusb.cfg"), "r") as f:
+            assert config.distro == f.read()
+        with open(os.path.join(install_dir, "iso_file_list.cfg"), 'r') as f:
+            _iso_file_list = [s.strip() for s in f.readlines()]
+
     log("Installing " + iso_name(config.image_path) + " on " + install_dir)
 
     # Some distros requires certain directories be at the root.
@@ -105,6 +115,12 @@ def install_distro():
     elif config.distro == 'insert':
         iso_extract_full(config.image_path, install_dir)
         relocator.move(('INSERT',))
+    elif config.distro == 'centos-install' and \
+      any(f=='.treeinfo' for f in _iso_file_list):
+        # DVD installer
+        iso.iso_extract_file(config.image_path, install_dir, '-xr-!Packages')
+        log("Copying the source iso file as is.")
+        copy_iso(config.image_path, install_dir)
     else:
         iso.iso_extract_full(config.image_path, install_dir)
 

--- a/scripts/param_rewrite.py
+++ b/scripts/param_rewrite.py
@@ -77,6 +77,7 @@ def contains_any_token(*tokens):
 
 def contains_key(key):
     assert type(key)==str
+    assert key[-1:] == '='
     return lambda starter, params: any(x.startswith(key) for x in params)
 
 def contains_all_keys(*keys):

--- a/scripts/persistence.py
+++ b/scripts/persistence.py
@@ -48,7 +48,7 @@ def persistence_distro(distro, iso_link):
 
 #     iso_size = iso.iso_size(iso_link)
 
-    if distro in ["ubuntu", "debian", "debian-install", "fedora"]:
+    if distro in ["ubuntu", "debian", "debian-install", "fedora", "centos"]:
         gen.log("Persistence option is available.")
         return distro
     else:
@@ -159,6 +159,10 @@ creator_dict = {
         create_persistence_using_resize2fs,
         lambda C: ('persistence',)),
     'fedora' : (
+        create_persistence_using_mkfs,
+        lambda C: (os.path.join(
+            'LiveOS', 'overlay-%s-%s' % (C.usb_label, C.usb_uuid)),)),
+    'centos' : (
         create_persistence_using_mkfs,
         lambda C: (os.path.join(
             'LiveOS', 'overlay-%s-%s' % (C.usb_label, C.usb_uuid)),)),


### PR DESCRIPTION
* Fix a rather critical bug in 'ConfigTweaker.tweak_first_match()' that got 'param_operation' contaminated with 'param_operations_for_persistence' as the recursion progress.
* Support CentOS DVD installers. Tested with CentOS-7-x86_64-(DVD/Minimal/NetInstall)-1708.iso  (Full install DVD requires ext3 formatted usb stick because its size exceeds 4GB.)
* Straighten CentOS Live DVD support. (Those were recognized as 'fedora' before this fix.)
* Fix 'add_op_if_file_exists()' to properly handle '/' prefixed to a path.
* Reorgazined Twaker classes a bit.
* Removed control chars and extra spaces in test inputs.
