### PR TITLE
Apply hack to prevent gfxboot from locking up when booting antiX-17

### DIFF
--- a/scripts/update_cfg_file.py
+++ b/scripts/update_cfg_file.py
@@ -896,6 +896,11 @@ class AntixConfigTweaker(NoPersistenceTweaker):
 
         return [(ops, starter_is_either('append', 'APPEND', 'linux'))]
 
+    def post_process(self, entire_string):
+        return entire_string.replace(
+            r'UI gfxboot gfx-cpio readme.msg',
+            r'UI gfxboot gfx-cpio.renamed_to_avoid_lockup readme.msg')
+
 
 def test_tweak_objects():
     def os_path_exists(f):


### PR DESCRIPTION
 via syslinux. Grub booting does not exhibit similar problem.
