### PR TITLE
Add Support for WifiSlax64-1.1-final

### DIFF
--- a/scripts/grub.py
+++ b/scripts/grub.py
@@ -44,6 +44,11 @@ def mbusb_update_grub_cfg():
         config.image_path,
         lambda x: os.path.basename(x).lower().startswith('grub') and
         os.path.basename(x).lower().endswith('.cfg'))
+    # favour 'grub.cfg' over variants.
+    flagged  = [(f, os.path.basename(f).lower()=='grub.cfg')
+                for f in grub_cfg_list]
+    grub_cfg_list = [ x[0] for x in flagged if x[1] ] + \
+                    [ x[0] for x in flagged if not x[1] ]
     candidates = []
     for src_list, predicate in [
             # List in the order of decreasing preference.

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -79,7 +79,8 @@ def install_distro():
     elif config.distro == "salix-live":
         # iso.iso_extract_file(config.image_path, install_dir, "boot")
         iso.iso_extract_file(config.image_path, install_dir,
-                             ['*syslinux', '*menus', '*vmlinuz', '*initrd*'])
+                             ['*syslinux', '*menus', '*vmlinuz', '*initrd*',
+                              'EFI'])
         iso.iso_extract_file(config.image_path, usb_mount,
                              ['*modules', '*packages', '*optional',
                               '*liveboot'])


### PR DESCRIPTION
**This PR may conflict with another pending PR. If so, please let me know.
I'll replace this PR with a new one.**

* Prefer 'grub.cfg' over other variants like 'grub-embedded.cfg'
* Extract the tree rooted at EFI/ as well.
* Probe .txt files other than 'thema.txt' for rewriting desktop-image:
setting.
* Add 'legacy_tweak()' method to ConfigTweakers to keep old behaviour.
* Add SalixConfigTweaker.