### PR TITLE
 Fix exception from opening utf-8 encoded text file

### DIFF
--- a/scripts/update_cfg_file.py
+++ b/scripts/update_cfg_file.py
@@ -374,7 +374,8 @@ def update_distro_cfg_files(iso_link, usb_disk, distro, persistence=0):
             return
         log("Probing '%s'!" % fname)
         theme_file = os.path.join(dir_, fname)
-        with open(theme_file, 'r') as f:
+        updated = False
+        with open(theme_file, 'r', encoding='utf-8') as f:
             lines = []
             pattern = re.compile(r'^desktop-image\s*:\s*(.*)$')
             for line in f.readlines():
@@ -382,12 +383,14 @@ def update_distro_cfg_files(iso_link, usb_disk, distro, persistence=0):
                 m = pattern.match(line)
                 if m:
                     log("Updating '%s'" % line)
+                    updated = True
                     partial_path = m.group(1).strip('"').lstrip('/')
                     line = 'desktop-image: "%s/%s"' % \
                            (install_dir_for_grub, partial_path)
                 lines.append(line)
-        with open(theme_file, 'w') as f:
-            f.write('\n'.join(lines))
+        if updated:
+            with open(theme_file, 'w') as f:
+                f.write('\n'.join(lines))
 
     visitor_callbacks = [
         # Ensure that isolinux.cfg file is copied as syslinux.cfg


### PR DESCRIPTION
Got an exception when installing _debian-9.4.0-amd64-netinst.sio_
because f.readlines() tried to convert utf-8 encoded text  to unicode assuming cp-932.
Now force utf-8 when opening target files.

Perform update only if disktop-image path was successfully tweaked.
