### PR TITLE
Address issues with Manjaro, Slitaz-rolloing and Salix-Live

### DIFF
--- a/scripts/install.py
+++ b/scripts/install.py
@@ -6,11 +6,12 @@
 # Licence:  This file is a part of multibootusb package. You can redistribute it or modify
 # under the terms of GNU General Public License, v.2 or above
 
+import lzma
 import os
-import shutil
 import platform
-import threading
+import shutil
 import subprocess
+import threading
 import time
 from .usb import *
 from .gen import *
@@ -182,48 +183,71 @@ def install_progress():
         time.sleep(0.1)
 
 
+def replace_syslinux_modules(syslinux_version, under_this_dir):
+    # Replace modules files extracted from iso with corresponding
+    # version provided by multibootusb.
+    modules_src_dir = os.path.join(
+        multibootusb_host_dir(), "syslinux", "modules", syslinux_version)
+
+    for dirpath, dirnames, filenames in os.walk(under_this_dir):
+        for fname in filenames:
+            if not fname.lower().endswith('.c32'):
+                continue
+            dst_path = os.path.join(under_this_dir, dirpath, fname)
+            src_path = os.path.join(modules_src_dir, fname)
+            if not os.path.exists(src_path):
+                log("Suitable replacement of '%s' is not bundled. "
+                    "Trying to unlzma." % fname)
+                try:
+                    with lzma.open(dst_path) as f:
+                        expanded = f.read()
+                except (OSError, IOError, lzma.LZMAError):
+                    continue
+                with open(dst_path, 'wb') as f:
+                    f.write(expanded)
+                log("Successfully dcompressed %s." % fname)
+                continue
+            try:
+                os.remove(dst_path)
+                shutil.copy(src_path, dst_path)
+                log("Replaced %s module" % fname)
+            except (OSError, IOError) as err:
+                log(err)
+                log("Could not update " + fname)
+
 def install_patch():
     """
     Function to certain distros which uses makeboot.sh script for making bootable usb disk.
     This is required to make sure that same version (32/64 bit) of modules present is the isolinux directory
     :return:
     """
-    if config.distro == 'debian':
+    iso_cfg_ext_dir = os.path.join(multibootusb_host_dir(),
+                                   "iso_cfg_ext_dir")
+    isolinux_path = os.path.join(iso_cfg_ext_dir,
+                                 isolinux_bin_path(config.image_path))
+#   iso_linux_bin_dir = isolinux_bin_dir(config.image_path)
+    distro_install_dir = os.path.join(
+        config.usb_mount, "multibootusb", iso_basename(config.image_path))
+    config.syslinux_version = isolinux_version(isolinux_path)
+
+    if config.distro == 'slitaz':
+        replace_syslinux_modules(config.syslinux_version, distro_install_dir)
+        c32box_path = os.path.join(distro_install_dir, 'boot', 'isolinux',
+                                   'c32box.c32')
+
+    elif config.distro == 'debian':
         if platform.system() == 'Linux':  # Need to syn under Linux. Otherwise, USB disk becomes random read only.
             os.sync()
-        iso_cfg_ext_dir = os.path.join(multibootusb_host_dir(), "iso_cfg_ext_dir")
-        isolinux_path = os.path.join(iso_cfg_ext_dir, isolinux_bin_path(config.image_path))
-#         iso_linux_bin_dir = isolinux_bin_dir(config.image_path)
-        config.syslinux_version = isolinux_version(isolinux_path)
         iso_file_list = iso.iso_file_list(config.image_path)
-
         if not any(s.strip().lower().endswith("makeboot.sh")
                    for s in iso_file_list):
             log('Patch not required...')
             return
 
-        # Replace modules files extracted from iso with corresponding
-        # version provided by multibootusb.
-        distro_install_dir = os.path.join(config.usb_mount, "multibootusb",
-                                          iso_basename(config.image_path))
         isolinux_bin_dir_ = os.path.join(
             distro_install_dir, isolinux_bin_dir(config.image_path))
-        modules_src_dir = os.path.join(
-            multibootusb_host_dir(), "syslinux", "modules",
-            config.syslinux_version)
-        for module in os.listdir(isolinux_bin_dir_):
-            if not module.endswith(".c32"):
-                continue
-            fpath = os.path.join(isolinux_bin_dir_, module)
-            try:
-                os.remove(fpath)
-                src_module_path = os.path.join(modules_src_dir, module)
-                log("Copying " +  module)
-                log((src_module_path, fpath))
-                shutil.copy(src_module_path, fpath)
-            except Exception as err:
-                log(err)
-                log("Could not copy " + module)
+        replace_syslinux_modules(config.syslinux_version, isolinux_bin_dir_)
+
 
 class DirectoryRelocator:
     def __init__(self, src_dir, dst_dir):

--- a/scripts/syslinux.py
+++ b/scripts/syslinux.py
@@ -224,17 +224,14 @@ def syslinux_distro_dir(usb_disk, iso_link, distro):
 #             log(distro_syslinux_install_dir)
 
         if usb_fs in syslinux_fs:
-            if config.syslinux_version == str(3):
-                if distro == "generic" and iso_linux_bin_dir == "/":
-                    option = ""
-                else:
-                    option = " -d "
-            else:
-                if distro == "generic" and iso_linux_bin_dir == "/":
-                    option = " -i "
-                else:
-                    option = " -i -d "
-
+            options = []
+            if getattr(config, 'allow_syslinux_on_fixed_drive', None):
+                options.append('-f')
+            if config.syslinux_version != '3':
+                options.append('-i')
+            if not (distro == "generic" and iso_linux_bin_dir == "/"):
+                options.append('-d')
+            option = ' ' + ' '.join(options) + ' '
             if platform.system() == "Linux":
                 syslinux_path = os.path.join(multibootusb_host_dir(), "syslinux", "bin", "syslinux") + config.syslinux_version
                 if os.access(syslinux_path, os.X_OK) is False:

--- a/scripts/update_cfg_file.py
+++ b/scripts/update_cfg_file.py
@@ -149,7 +149,7 @@ def update_distro_cfg_files(iso_link, usb_disk, distro, persistence=0):
         'centos-install' : CentosConfigTweaker,
         'antix'          : AntixConfigTweaker,
         'salix-live'     : SalixConfigTweaker,
-        'wifislax'       : SalixConfigTweaker,
+        'wifislax'       : WifislaxConfigTweaker,
         }
     tweaker_class = tweaker_class_dict.get(distro)
 
@@ -933,6 +933,14 @@ class SalixConfigTweaker(NoPersistenceTweaker):
             content = content.replace(replacee, replacer)
         return content
 
+    # salixlive-xfce-14.2.1 assumes that the installation media is
+    # labeled "LIVE" and the file tree is exploded at the root.
+    # (See /init for details.) Supporing it in harmony with installation
+    # of other distros is very hard to impossible. Do nothing here.
+    def param_operations(self):
+        return []
+
+class WifislaxConfigTweaker(NoPersistenceTweaker):
     def param_operations(self):
         ops = [
             (add_or_replace_kv('livemedia=','%s:%s/%s.iso' % (

--- a/scripts/update_cfg_file.py
+++ b/scripts/update_cfg_file.py
@@ -435,50 +435,55 @@ def update_mbusb_cfg_file(iso_link, usb_uuid, usb_mount, distro):
     if platform.system() == 'Linux':
         os.sync()
     log('Updating multibootusb config file...')
+    name_from_iso = iso_basename(iso_link)
+    name_of_iso = iso_name(iso_link)
+    _isolinux_bin_exists = isolinux_bin_exist(config.image_path)
+    _isolinux_bin_dir = isolinux_bin_dir(iso_link)
     sys_cfg_file = os.path.join(usb_mount, "multibootusb", "syslinux.cfg")
-    install_dir = os.path.join(usb_mount, "multibootusb", iso_basename(iso_link))
-    if os.path.exists(sys_cfg_file):
+    install_dir = os.path.join(usb_mount, "multibootusb", name_from_iso)
+    label = name_from_iso + ('' if _isolinux_bin_exists else ' via GRUB')
 
+    if os.path.exists(sys_cfg_file):
         if distro == "hbcd":
             if os.path.exists(os.path.join(usb_mount, "multibootusb", "menu.lst")):
                 _config_file = os.path.join(usb_mount, "multibootusb", "menu.lst")
                 config_file = open(_config_file, "w")
-                string = re.sub(r'/HBCD', '/multibootusb/' + iso_basename(iso_link) + '/HBCD', _config_file)
+                string = re.sub(r'/HBCD', '/multibootusb/' + name_from_iso + '/HBCD', _config_file)
                 config_file.write(string)
                 config_file.close()
             with open(sys_cfg_file, "a") as f:
                 f.write("#start " + iso_basename(config.image_path) + "\n")
-                f.write("LABEL " + iso_basename(config.image_path) + "\n")
-                f.write("MENU LABEL " + iso_basename(config.image_path) + "\n")
-                f.write("BOOT " + '/multibootusb/' + iso_basename(iso_link) + '/' + isolinux_bin_dir(iso_link).replace("\\", "/") + '/' + distro + '.bs' + "\n")
+                f.write("LABEL " + label + "\n")
+                f.write("MENU LABEL " + label + "\n")
+                f.write("BOOT " + '/multibootusb/' + name_from_iso + '/' + _isolinux_bin_dir.replace("\\", "/") + '/' + distro + '.bs' + "\n")
                 f.write("#end " + iso_basename(config.image_path) + "\n")
         elif distro == "Windows":
             if os.path.exists(sys_cfg_file):
                 config_file = open(sys_cfg_file, "a")
-                config_file.write("#start " + iso_basename(iso_link) + "\n")
-                config_file.write("LABEL " + iso_basename(iso_link) + "\n")
-                config_file.write("MENU LABEL " + iso_basename(iso_link) + "\n")
+                config_file.write("#start " + name_from_iso + "\n")
+                config_file.write("LABEL " + label + "\n")
+                config_file.write("MENU LABEL " + label + "\n")
                 config_file.write("KERNEL chain.c32 hd0 1 ntldr=/bootmgr" + "\n")
-                config_file.write("#end " + iso_basename(iso_link) + "\n")
+                config_file.write("#end " + name_from_iso + "\n")
                 config_file.close()
         elif distro == 'f4ubcd':
             if os.path.exists(sys_cfg_file):
                 config_file = open(sys_cfg_file, "a")
-                config_file.write("#start " + iso_basename(iso_link) + "\n")
-                config_file.write("LABEL " + iso_basename(iso_link) + "\n")
-                config_file.write("MENU LABEL " + iso_basename(iso_link) + "\n")
+                config_file.write("#start " + name_from_iso + "\n")
+                config_file.write("LABEL " + label + "\n")
+                config_file.write("MENU LABEL " + label + "\n")
                 config_file.write("KERNEL grub.exe" + "\n")
                 config_file.write('APPEND --config-file=/multibootusb/' + iso_basename(config.image_path) + '/menu.lst' + "\n")
-                config_file.write("#end " + iso_basename(iso_link) + "\n")
+                config_file.write("#end " + name_from_iso + "\n")
                 config_file.close()
         elif distro == 'kaspersky':
             if os.path.exists(sys_cfg_file):
                 config_file = open(sys_cfg_file, "a")
-                config_file.write("#start " + iso_basename(iso_link) + "\n")
-                config_file.write("LABEL " + iso_basename(iso_link) + "\n")
-                config_file.write("MENU LABEL " + iso_basename(iso_link) + "\n")
+                config_file.write("#start " + name_from_iso + "\n")
+                config_file.write("LABEL " + label + "\n")
+                config_file.write("MENU LABEL " + label + "\n")
                 config_file.write("CONFIG " + '/multibootusb/' + iso_basename(config.image_path) + '/kaspersky.cfg' + "\n")
-                config_file.write("#end " + iso_basename(iso_link) + "\n")
+                config_file.write("#end " + name_from_iso + "\n")
                 config_file.close()
         elif distro == 'grub4dos':
             update_menu_lst()
@@ -486,27 +491,27 @@ def update_mbusb_cfg_file(iso_link, usb_uuid, usb_mount, distro):
             update_grub4dos_iso_menu()
         else:
             config_file = open(sys_cfg_file, "a")
-            config_file.write("#start " + iso_basename(iso_link) + "\n")
-            config_file.write("LABEL " + iso_basename(iso_link) + "\n")
-            config_file.write("MENU LABEL " + iso_basename(iso_link) + "\n")
+            config_file.write("#start " + name_from_iso + "\n")
+            config_file.write("LABEL " + label + "\n")
+            config_file.write("MENU LABEL " + label + "\n")
             if distro == "salix-live":
-                if os.path.exists(os.path.join(config.usb_mount, 'multibootusb', iso_basename(iso_link), 'boot', 'grub2-linux.img')):
+                if os.path.exists(os.path.join(config.usb_mount, 'multibootusb', name_from_iso, 'boot', 'grub2-linux.img')):
                     config_file.write(
-                        "LINUX " + '/multibootusb/' + iso_basename(iso_link) + '/boot/grub2-linux.img' + "\n")
+                        "LINUX " + '/multibootusb/' + name_from_iso + '/boot/grub2-linux.img' + "\n")
                 else:
-                    config_file.write("BOOT " + '/multibootusb/' + iso_basename(iso_link) + '/' + isolinux_bin_dir(iso_link).replace("\\", "/") + '/' + distro + '.bs' + "\n")
+                    config_file.write("BOOT " + '/multibootusb/' + name_from_iso + '/' + _isolinux_bin_dir.replace("\\", "/") + '/' + distro + '.bs' + "\n")
             elif distro == "pclinuxos":
-                config_file.write("kernel " + '/multibootusb/' + iso_basename(iso_link) + '/isolinux/vmlinuz' + "\n")
+                config_file.write("kernel " + '/multibootusb/' + name_from_iso + '/isolinux/vmlinuz' + "\n")
                 config_file.write("append livecd=livecd root=/dev/rd/3 acpi=on vga=788 keyb=us vmalloc=256M nokmsboot "
                                   "fromusb root=UUID=" + usb_uuid + " bootfromiso=/multibootusb/" +
-                                  iso_basename(iso_link) + "/" + iso_name(iso_link) + " initrd=/multibootusb/"
-                                  + iso_basename(iso_link) + '/isolinux/initrd.gz' + "\n")
+                                  name_from_iso + "/" + name_of_iso + " initrd=/multibootusb/"
+                                  + name_from_iso + '/isolinux/initrd.gz' + "\n")
             elif distro == "memtest":
-                config_file.write("kernel " + '/multibootusb/' + iso_basename(iso_link) + '/BOOT/MEMTEST.IMG\n')
+                config_file.write("kernel " + '/multibootusb/' + name_from_iso + '/BOOT/MEMTEST.IMG\n')
 
             elif distro == "sgrubd2" or config.distro == 'raw_iso':
                 config_file.write("LINUX memdisk\n")
-                config_file.write("INITRD " + "/multibootusb/" + iso_basename(iso_link) + '/' + iso_name(iso_link) + '\n')
+                config_file.write("INITRD " + "/multibootusb/" + name_from_iso + '/' + name_of_iso + '\n')
                 config_file.write("APPEND iso\n")
 
             elif distro == 'ReactOS':
@@ -524,30 +529,37 @@ def update_mbusb_cfg_file(iso_link, usb_uuid, usb_mount, distro):
             elif distro == 'memdisk_img':
                 config_file.write(menus.memdisk_img_cfg(syslinux=True, grub=False))
             else:
-                if isolinux_bin_exist(config.image_path) is True:
+                if _isolinux_bin_exists is True:
                     if distro == "generic":
-                        distro_syslinux_install_dir = isolinux_bin_dir(iso_link)
-                        if isolinux_bin_dir(iso_link) != "/":
-                            distro_sys_install_bs = os.path.join(usb_mount, isolinux_bin_dir(iso_link)) + '/' + distro + '.bs'
+                        distro_syslinux_install_dir = _isolinux_bin_dir
+                        if _isolinux_bin_dir != "/":
+                            distro_sys_install_bs = os.path.join(usb_mount, _isolinux_bin_dir) + '/' + distro + '.bs'
                         else:
                             distro_sys_install_bs = '/' + distro + '.bs'
                     else:
                         distro_syslinux_install_dir = install_dir
                         distro_syslinux_install_dir = distro_syslinux_install_dir.replace(usb_mount, '')
-                        distro_sys_install_bs = distro_syslinux_install_dir + '/' + isolinux_bin_dir(iso_link) + '/' + distro + '.bs'
+                        distro_sys_install_bs = distro_syslinux_install_dir + '/' + _isolinux_bin_dir + '/' + distro + '.bs'
 
                     distro_sys_install_bs = "/" + distro_sys_install_bs.replace("\\", "/")  # Windows path issue.
 
                     if config.syslinux_version == '3':
-                        config_file.write("CONFIG /multibootusb/" + iso_basename(iso_link) + '/' + isolinux_bin_dir(iso_link).replace("\\", "/") + '/isolinux.cfg\n')
-                        config_file.write("APPEND /multibootusb/" + iso_basename(iso_link) + '/' + isolinux_bin_dir(iso_link).replace("\\", "/") + '\n')
+                        config_file.write("CONFIG /multibootusb/" + name_from_iso + '/' + _isolinux_bin_dir.replace("\\", "/") + '/isolinux.cfg\n')
+                        config_file.write("APPEND /multibootusb/" + name_from_iso + '/' + _isolinux_bin_dir.replace("\\", "/") + '\n')
                         config_file.write("# Delete or comment above two lines using # and remove # from below line if "
                                           "you get not a COM module error.\n")
                         config_file.write("#BOOT " + distro_sys_install_bs.replace("//", "/") + "\n")
                     else:
                         config_file.write("BOOT " + distro_sys_install_bs.replace("//", "/") + "\n")
-
-            config_file.write("#end " + iso_basename(iso_link) + "\n")
+                else:
+                    # isolinux_bin does not exist.
+                    config_file.write('Linux /multibootusb/grub/lnxboot.img\n')
+                    config_file.write('INITRD /multibootusb/grub/core.img\n')
+                    config_file.write('TEXT HELP\n')
+                    config_file.write('Booting via syslinux is not supported. '
+                                      'Please boot via GRUB\n')
+                    config_file.write('ENDTEXT\n')
+            config_file.write("#end " + name_from_iso + "\n")
             config_file.close()
             # Update extlinux.cfg file by copying updated syslinux.cfg
             shutil.copy(os.path.join(usb_mount, 'multibootusb', 'syslinux.cfg'),


### PR DESCRIPTION
Please see the commit messages for details.

@mbusb, what is the reason that let you apply syslinux module replacement only to debian?
Would not it make sense to do the same for all distros?
