### PR TITLE
Postfix menu-entry with an architecture name when generating

### DIFF
--- a/scripts/grub.py
+++ b/scripts/grub.py
@@ -295,7 +295,7 @@ def iso2grub2(install_dir, loopback_cfg_path):
     gen.log('loopback.cfg file is set to ' + loopback_cfg_path)
 
     iso_bin_dir = iso.isolinux_bin_dir(config.image_path)
-    seen_menu_lines = []
+    seen_menu_entries = []
     # Loop though the distro installed directory for finding config files
     for dirpath, dirnames, filenames in os.walk(install_dir):
         for f in filenames:
@@ -345,7 +345,7 @@ def iso2grub2(install_dir, loopback_cfg_path):
                 menu_labels = [v for v in matches if v[0].lower()=='menu label']
                 if 0 == len(labels) + len(menu_labels):
                     gen.log('Warning: found a block without menu-entry.')
-                    menu_line = 'menuentry "Anonymous"'
+                    menu_entry = 'Anonymous'
                     menu_label = 'Unlabeled'
                 else:
                     for vec, name in [ (labels, 'label'),
@@ -358,13 +358,14 @@ def iso2grub2(install_dir, loopback_cfg_path):
                         value = menu_labels[0][1].replace('^', '')
                     else:
                         value = labels[0][1]
-                    menu_line = 'menuentry ' + gen.quote(value)
-                    menu_label = value
+                    menu_entry = menu_label = value
 
                 # Extract lines containing 'kernel','linux','initrd'
                 # or 'append' to convert them into grub2 compatible ones.
                 linux_line = initrd_line = None
                 appends = []
+                sought_archs = ['x86_64', 'i686', 'i386']
+                arch = []
                 for keyword, value in re.findall(
                         r'^\s*(kernel|linux|initrd|append)[= ](.*)$',
                         matching_block, re.I|re.MULTILINE):
@@ -375,6 +376,8 @@ def iso2grub2(install_dir, loopback_cfg_path):
                                     "'kernel/linux' lines in block '%s'."
                                     % menu_label)
                             continue
+                        arch = [(value.find(a), a) for a in sought_archs
+                                if 0 <= value.find(a)]
                         linux_line = 'linux ' + \
                                      tweak_bootfile_path(value, iso_bin_dir)
                     elif kw == 'initrd':
@@ -396,13 +399,15 @@ def iso2grub2(install_dir, loopback_cfg_path):
                                         "specifications in block '%s'."
                                         % menu_label)
                             initrd_line = new_initrd_line
-
-                if menu_line in seen_menu_lines:
+                if arch: # utilize left most arch.
+                    menu_entry += (" (%s)" % sorted(arch)[-1][1])
+                menu_line = 'menuentry ' + gen.quote(menu_entry)
+                if menu_entry in seen_menu_entries:
                     out_lines.append( "# '%s' is superceded by the previous "
                                       "definition." % menu_label)
                 else:
                     if linux_line or initrd_line:
-                        seen_menu_lines.append(menu_line)
+                        seen_menu_entries.append(menu_entry)
                         out_lines.append(menu_line + ' {')
                         for starter, value in [
                                 (linux_line, ' '.join(appends)),


### PR DESCRIPTION
loopback.cfg so that one for i686 won't hide another for x86_64
or vice versa.