### PR TITLE
Fix exception from install_path() and other enhancements

### DIFF
--- a/scripts/gen.py
+++ b/scripts/gen.py
@@ -76,7 +76,7 @@ def resource_path(relativePath):
             #basePath = os.path.abspath(".")
             basePath = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
-    for dir_ in [basePath, os.path.abspath('.'), os.path.abspath('..')]:
+    for dir_ in [os.path.abspath('.'), os.path.abspath('..'), basePath]:
         fullpath = os.path.join(dir_, relativePath)
         if os.path.exists(fullpath):
             return fullpath

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -221,10 +221,13 @@ def install_patch():
     This is required to make sure that same version (32/64 bit) of modules present is the isolinux directory
     :return:
     """
+    isobin_path = isolinux_bin_path(config.image_path)
+    if not isobin_path:
+        return
+
     iso_cfg_ext_dir = os.path.join(multibootusb_host_dir(),
                                    "iso_cfg_ext_dir")
-    isolinux_path = os.path.join(iso_cfg_ext_dir,
-                                 isolinux_bin_path(config.image_path))
+    isolinux_path = os.path.join(iso_cfg_ext_dir, isobin_path)
 #   iso_linux_bin_dir = isolinux_bin_dir(config.image_path)
     distro_install_dir = os.path.join(
         config.usb_mount, "multibootusb", iso_basename(config.image_path))


### PR DESCRIPTION
Fix exception from install_patch() raised when a distro does not have isolinux_bin_dir.
Support an alternate bios when running QEMU.
Try relative paths first before /usr/share/multibootusb when locating a resource.
