### PR TITLE
Refactor delete_frm_file_list() to keep /EFI

### DIFF
--- a/scripts/install.py
+++ b/scripts/install.py
@@ -97,8 +97,12 @@ def install_distro():
         iso.iso_extract_file(config.image_path, install_dir, '-xr!*rescue')
         iso.iso_extract_file(config.image_path, config.usb_mount, 'rescue')
     elif config.distro == "generic":
-        #with open(os.path.join(install_dir, "generic.cfg"), "w") as f:
-        #    f.write(os.path.join(isolinux_bin_dir(config.image_path), "generic") + ".bs")
+        # If you uncomment the code below, make sure you update
+        # uninstall.delete_files_at_drive_root() accordingly.
+        #
+        # with open(os.path.join(install_dir, "generic.cfg"), "w") as f:
+        #     f.write(os.path.join(isolinux_bin_dir(config.image_path), "generic") + ".bs")
+
         iso_extract_full(config.image_path, usb_mount)
     elif config.distro == 'grub4dos':
         iso_extract_full(config.image_path, usb_mount)

--- a/scripts/uninstall_distro.py
+++ b/scripts/uninstall_distro.py
@@ -66,7 +66,7 @@ def delete_files_at_drive_root(iso_file_list, uninstall_distro_dir_name):
             gen.log('Could not remove ldlinux.sys')
 
     for f in iso_file_list:
-        f = f.replace('\n/')
+        f = f.rstrip('\n/')
         if platform.system() == "Windows":
             f = f.replace("/", "\\")
         fullpath = os.path.join(usb_mount, f)


### PR DESCRIPTION
usefull work (the distro-dir should have been removed by shutil.rmtree()
by the time this function is called) but can potentially remove files that
are not indented for deletion due to wrong path composition. For example
it tries to remove /EFI rather than /multibootusb/{distro-dir}/EFI.