### PR TITLE
Avoid catch-all exception handling.

### DIFF
--- a/multibootusb
+++ b/multibootusb
@@ -33,13 +33,13 @@ try:
     from scripts import admin
     from scripts import gen
     from scripts import config
-except:
+except ImportError:
     try:
         from .scripts.mbusb_cli import *
         from .scripts import admin
         from .scripts import gen
         from .scripts import config
-    except:
+    except ImportError:
         import scripts
 
 gui = True


### PR DESCRIPTION
Catching all exception types obscures exceptions that are not anticipated.
@mbusb, please suggest amendments if this does not achieve what you intended.
(Would it not be possible to remove all import retries? )
