### PR TITLE
Fix on Imager and add warning about running 'mbr_install_cmd'.

### DIFF
--- a/scripts/mbusb_gui.py
+++ b/scripts/mbusb_gui.py
@@ -31,7 +31,7 @@ from .distro import *
 from .qemu import *
 from .iso import *
 # from .imager import *
-from .imager import Imager, dd_linux, dd_win
+from .imager import Imager, dd_iso_image
 from . import persistence
 from . import config
 from . import admin
@@ -731,8 +731,15 @@ Proceed with installation?'''.lstrip() % \
 		config.process_exist = None
 
 		msgBox = QtWidgets.QMessageBox()
-		msgBox.setText("Image succesfully written to USB disk.")
-		msgBox.setInformativeText("Reboot to boot from USB or test it from <b>Boot ISO/USB</b> tab.");
+		if self.progress_thread_dd.error:
+			title = "Failed to write the iso image to the USB disk."
+			msg = self.progress_thread_dd.error
+		else:
+			title = "Image succesfully written to USB disk."
+			msg = "Reboot to boot from USB or test it from " \
+			  "<b>Boot ISO/USB</b> tab."
+		msgBox.setText(title)
+		msgBox.setInformativeText(msg);
 		msgBox.setStandardButtons(QtWidgets.QMessageBox.Ok)
 		msgBox.setIcon(QtWidgets.QMessageBox.Information)
 		msgBox.exec_()
@@ -960,14 +967,14 @@ class DD_Progress(QtCore.QThread):
 
 	def __init__(self):
 		QtCore.QThread.__init__(self)
-
-		if platform.system() == 'Linux':
-			self.thread = GenericThread(dd_linux)
-		elif platform.system() == 'Windows':
-			self.thread = GenericThread(dd_win)
+		self.error = None
+		self.thread = GenericThread(partial(dd_iso_image, self))
 
 	def __del__(self):
 		self.wait()
+
+	def set_error(self, error):
+		self.error = error
 
 	def run(self):
 		self.thread.start()

--- a/scripts/osdriver.py
+++ b/scripts/osdriver.py
@@ -144,7 +144,7 @@ class Base:
         in_file_size = os.path.getsize(input_)
 
         cmd = [self.dd_exe, 'if=' + input_,
-               'of=' + self.dd_iso_image_physical_disk(output), 'bs=1M']
+               'of=' + self.physical_disk(output), 'bs=1M']
         self.dd_iso_image_add_args(cmd, input_, output)
         log('Executing => ' + str(cmd))
         kw_args = {
@@ -203,9 +203,6 @@ class Windows(Base):
         else:
             return None
 
-    def dd_iso_image_physical_disk(self, usb_disk):
-        return '\\\\.\\' + usb_disk
-
     def physical_disk(self, usb_disk):
         return r'\\.\physicaldrive%d' % get_physical_disk_number(usb_disk)
 
@@ -250,9 +247,6 @@ class Linux(Base):
 
     def dd_iso_image_interpret_result(self, returncode, error_list):
         return None if returncode==0 else '\n'.join(error_list)
-
-    def dd_iso_image_physical_disk(self, usb_disk):
-        return usb_disk.rstrip('0123456789')
 
     def physical_disk(self, usb_disk):
         return usb_disk.rstrip('0123456789')

--- a/scripts/osdriver.py
+++ b/scripts/osdriver.py
@@ -143,7 +143,8 @@ class Base:
     def dd_iso_image(self, input_, output, gui_update):
         in_file_size = os.path.getsize(input_)
 
-        cmd = [self.dd_exe, 'if='+input_, 'of='+output, 'bs=1M']
+        cmd = [self.dd_exe, 'if=' + input_,
+               'of=' + self.dd_iso_image_physical_disk(output), 'bs=1M']
         self.dd_iso_image_add_args(cmd, input_, output)
         log('Executing => ' + str(cmd))
         kw_args = {
@@ -157,11 +158,9 @@ class Base:
         while dd_process.poll() is None:
             self.dd_iso_image_readoutput(dd_process, gui_update, in_file_size,
                                          errors)
-        if dd_process.returncode == 0:
-            return None
-        else:
-            return ''.join([errors.get() for i in range(errors.qsize())]) or \
-              "'dd' returned exit-code:%d" % dd_process.returncode
+        error_list = [errors.get() for i in range(errors.qsize())]
+        return self.dd_iso_image_interpret_result(
+            dd_process.returncode, error_list)
 
 class Windows(Base):
 
@@ -181,15 +180,31 @@ class Windows(Base):
                                 error_log):
         for line in iter(dd_process.stderr.readline, ''):
             line = line.strip()
-            if line and line[-1:] == 'M':
-                bytes_copied = float(line.rstrip('M').replace(',', '')) \
-                  * 1024 * 1024
-                gui_update(byets_copied / in_file_size * 100.)
-            else:
-                if 16 < error_log.qsize():
-                    error_log.get()
-                error_log.put(line)
+            if line:
+                l = line.replace(',', '')
+                if l[-1:] == 'M':
+                    bytes_copied = float(l.rstrip('M')) * 1024 * 1024
+                elif l.isdigit():
+                    bytes_copied = float(l)
+                else:
+                    if 16 < error_log.qsize():
+                        error_log.get()
+                    error_log.put(line)
+                    continue
+                gui_update(bytes_copied / in_file_size * 100.)
+                continue
         # Now the 'dd' process should have completed or going to soon.
+
+    def dd_iso_image_interpret_result(self, returncode, error_list):
+        # dd.exe always returns 0
+        if any([ 'invalid' in s or 'error' in s for s
+                 in [l.lower() for l in error_list] ]):
+            return '\n'.join(error_list)
+        else:
+            return None
+
+    def dd_iso_image_physical_disk(self, usb_disk):
+        return '\\\\.\\' + usb_disk
 
     def physical_disk(self, usb_disk):
         return r'\\.\physicaldrive%d' % get_physical_disk_number(usb_disk)
@@ -232,6 +247,12 @@ class Linux(Base):
             else:
                 # stderr is closed
                 break
+
+    def dd_iso_image_interpret_result(self, returncode, error_list):
+        return None if returncode==0 else '\n'.join(error_list)
+
+    def dd_iso_image_physical_disk(self, usb_disk):
+        return usb_disk.rstrip('0123456789')
 
     def physical_disk(self, usb_disk):
         return usb_disk.rstrip('0123456789')

--- a/scripts/osdriver.py
+++ b/scripts/osdriver.py
@@ -2,9 +2,12 @@ import logging
 import logging.handlers
 import os
 import platform
+import queue
 import shutil
+import signal
 import subprocess
 import sys
+import time
 
 
 def log(message, info=True, error=False, debug=False, _print=True):
@@ -136,6 +139,30 @@ class Base:
         else:
             log("%s succeeded." % str(cmd))
 
+
+    def dd_iso_image(self, input_, output, gui_update):
+        in_file_size = os.path.getsize(input_)
+
+        cmd = [self.dd_exe, 'if='+input_, 'of='+output, 'bs=1M']
+        self.dd_iso_image_add_args(cmd, input_, output)
+        log('Executing => ' + str(cmd))
+        kw_args = {
+            'stdout' : subprocess.PIPE,
+            'stderr' : subprocess.PIPE,
+            'shell'  : False,
+            }
+        self.add_dd_iso_image_popen_args(kw_args)
+        dd_process = subprocess.Popen(cmd, **kw_args)
+        errors = queue.Queue()
+        while dd_process.poll() is None:
+            self.dd_iso_image_readoutput(dd_process, gui_update, in_file_size,
+                                         errors)
+        if dd_process.returncode == 0:
+            return None
+        else:
+            return ''.join([errors.get() for i in range(errors.qsize())]) or \
+              "'dd' returned exit-code:%d" % dd_process.returncode
+
 class Windows(Base):
 
     def __init__(self):
@@ -143,6 +170,26 @@ class Windows(Base):
 
     def dd_add_args(self, cmd_vec, input, output, bs, count):
         pass
+
+    def dd_iso_image_add_args(self, cmd_vec, input_, output):
+        cmd_vec.append('--progress')
+
+    def add_dd_iso_image_popen_args(self, dd_iso_image_popen_args):
+        dd_iso_image_popen_args['universal_newlines'] = True
+
+    def dd_iso_image_readoutput(self, dd_process, gui_update, in_file_size,
+                                error_log):
+        for line in iter(dd_process.stderr.readline, ''):
+            line = line.strip()
+            if line and line[-1:] == 'M':
+                bytes_copied = float(line.rstrip('M').replace(',', '')) \
+                  * 1024 * 1024
+                gui_update(byets_copied / in_file_size * 100.)
+            else:
+                if 16 < error_log.qsize():
+                    error_log.get()
+                error_log.put(line)
+        # Now the 'dd' process should have completed or going to soon.
 
     def physical_disk(self, usb_disk):
         return r'\\.\physicaldrive%d' % get_physical_disk_number(usb_disk)
@@ -157,6 +204,34 @@ class Linux(Base):
 
     def dd_add_args(self, cmd_vec, input, output, bs, count):
         cmd_vec.append('conv=notrunc')
+
+    def dd_iso_image_add_args(self, cmd_vec, input_, output):
+        cmd_vec.append('oflag=sync')
+
+    def add_dd_iso_image_popen_args(self, dd_iso_image_popen_args):
+        pass
+
+    def dd_iso_image_readoutput(self, dd_process, gui_update, in_file_size,
+                                error_log):
+        # If this time delay is not given, the Popen does not execute
+        # the actual command
+        time.sleep(0.1)
+        dd_process.send_signal(signal.SIGUSR1)
+        dd_process.stderr.flush()
+        while True:
+            time.sleep(0.1)
+            out_error = dd_process.stderr.readline().decode()
+            if out_error:
+                if 'bytes' in out_error:
+                    bytes_copied = float(out_error.split(' ', 1)[0])
+                    gui_update( bytes_copied / in_file_size * 100. )
+                    break
+                if 16 < error_log.qsize():
+                    error_log.get()
+                error_log.put(out_error)
+            else:
+                # stderr is closed
+                break
 
     def physical_disk(self, usb_disk):
         return usb_disk.rstrip('0123456789')
@@ -177,6 +252,7 @@ for func_name in [
         'run_dd',
         'physical_disk',
         'mbusb_log_file',
+        'dd_iso_image',
         ]:
     globals()[func_name] = getattr(osdriver, func_name)
 

--- a/scripts/syslinux.py
+++ b/scripts/syslinux.py
@@ -198,6 +198,12 @@ def syslinux_default(usb_disk):
                 '''
                 if config.usb_gpt is False:
                     log('\nExecuting ==> ' + mbr_install_cmd)
+                    #
+                    # Updating mbr using dd results in catastrophy.
+                    # Windows will lose track of the filesystem and
+                    # the target volume will go away.
+                    # Never enable this code without proper work around!
+                    #
                     if subprocess.call(mbr_install_cmd, shell=True) == 0:
                         log("\nmbr install is success...\n")
                         return True

--- a/scripts/udisks.py
+++ b/scripts/udisks.py
@@ -15,18 +15,25 @@ import os
 import re
 
 
-def node_mountpoint(node):
+def de_mangle_mountpoint(raw):
+    return raw.replace('\\040', ' ').replace('\\011', '\t') \
+      .replace('\\012', '\n').replace('\\0134', '\\')
 
-    def de_mangle(raw):
-        return raw.replace('\\040', ' ').replace('\\011', '\t').replace('\\012',
-                '\n').replace('\\0134', '\\')
+def node_mountpoint(node):
 
     for line in open('/proc/mounts').readlines():
         line = line.split()
         if line[0] == node:
-            return de_mangle(line[1])
+            return de_mangle_mountpoint(line[1])
     return None
 
+def find_partitions_on(disk):
+    assert not disk[-1:].isdigit()
+    with open('/proc/mounts') as f:
+        relevant_lines = [l.split(' ') for l in f.readlines()
+                          if l.startswith(disk)]
+    return [ [v[0], de_mangle_mountpoint(v[1])] + v[2:] for v
+             in relevant_lines ]
 
 class NoUDisks1(Exception):
     pass

--- a/scripts/usb.py
+++ b/scripts/usb.py
@@ -476,7 +476,7 @@ class UnmountedContext:
         gen.log("Unmounted %s" % self.usb_disk)
         return self
 
-    def __exit__(self, type, value, traceback_):
+    def __exit__(self, type_, value, traceback_):
         if not self.is_relevant:
             return
         os.sync()     # This should not be strictly necessary


### PR DESCRIPTION
Handle exception raised during imaging.
Unify progress display between Windows and Linux.
Move platform dependent code to osdriver.py
Unmount all partitions that belongs to the drive being written to.
Write to \\.\\PhysicalDriveX  instead of  \\.\X: on Windows (**but the operation fails at the moment**)

Add warning about dding MBR.
Avoid using reserved keyword 'type' as a variable name.
