### PR TITLE
properly handle loop device paths

### DIFF
--- a/scripts/gen.py
+++ b/scripts/gen.py
@@ -346,6 +346,30 @@ def write_to_file(filepath, text):
         f.write(text.strip())
 
 
+def physical_disk(partition):
+    if platform.system() == "Windows":
+        partition, logical_disk = wmi_get_drive_info(partition)
+        return r'\\.\physicaldrive%d' % logical_disk.DiskIndex
+    elif platform.system() == "Linux":
+        if partition.startswith('/dev/sd'):
+            return partition.rstrip('0123456789')
+        elif partition.startswith('/dev/loop'):
+            if partition.count('p') == 1:
+                # 'p' is from /dev/looPx, so return the original string
+                return partition
+            elif partition.count('p') == 2:
+                # 'p's are from /dev/looPxPy, so return up to the loop device number
+                return 'p'.join(partition.split('p')[:2])
+
+
+def is_partition(path):
+    if path.startswith('/dev/sd'):
+        return path[-1].isdigit()
+    elif path.startswith('/dev/loop'):
+        # loop device partitions use /dev/loopxpy as path, so check for a second 'p'
+        return path.count('p') == 2
+
+
 class MemoryCheck():
     """
     Cross platform way to checks memory of a given system. Works on Linux and Windows.

--- a/scripts/mbusb_cli.py
+++ b/scripts/mbusb_cli.py
@@ -138,7 +138,7 @@ def cli_dd():
     :return:
     """
     if platform.system() == 'Linux':
-        if config.usb_disk[-1].isdigit() is True:
+        if is_partition(config.usb_disk) is True:
             log('Selected USB is a disk partition. Please select the whole disk eg. \'/dev/sdb\'')
             sys.exit(2)
 
@@ -173,7 +173,7 @@ def cli_install_syslinux():
     """
     usb.gpt_device(config.usb_disk)
     if platform.system() == 'Linux':
-        if config.usb_disk[-1].isdigit() is not True:
+        if is_partition(config.usb_disk) is not True:
             log('Selected USB disk is not a partition. Please enter the partition eg. \'/dev/sdb1\'')
             sys.exit(2)
 

--- a/scripts/mbusb_gui.py
+++ b/scripts/mbusb_gui.py
@@ -412,7 +412,7 @@ class AppGui(qemu.Qemu, Imager, QtWidgets.QMainWindow, Ui_MainWindow):
 											  "No USB device found.\n\nInsert USB and use Refresh USB button to detect USB.")
 		elif platform.system() == "Linux" or platform.system() == "Windows":
 			if self.ui.check_install_sys_all.isChecked() or self.ui.check_install_sys_only.isChecked():
-				if platform.system() == 'Linux' and config.usb_disk[-1].isdigit() is False:
+				if platform.system() == 'Linux' and is_partition(config.usb_disk) is False:
 					gen.log('Selected USB is a disk. Please select a disk partition from the drop down list')
 					QtWidgets.QMessageBox.information(self, 'No Partition...!',
 													  'USB disk selected doesn\'t contain a partition.\n'
@@ -476,7 +476,7 @@ class AppGui(qemu.Qemu, Imager, QtWidgets.QMainWindow, Ui_MainWindow):
 				self, 'No partition is selected',
 				'Please select the partition to check.')
 			return
-		if not config.usb_disk[-1:].isdigit():
+		if not is_partition(config.usb_disk):
 			QtWidgets.QMessageBox.information(
 				self, 'Selected device is not partition',
 				'Please select a partition not a disk.')

--- a/scripts/syslinux.py
+++ b/scripts/syslinux.py
@@ -37,7 +37,7 @@ def gpt_part_table(usb_disk):
     :return: True if GPT else False
     """
     if platform.system() == "Linux":
-        _cmd_out = subprocess.check_output("parted  " + usb_disk[:-1] + " print", shell=True)
+        _cmd_out = subprocess.check_output("parted  " + physical_disk(usb_disk) + " print", shell=True)
         if b'msdos' in _cmd_out:
             return False
         elif b'gpt' in _cmd_out:
@@ -67,31 +67,31 @@ def get_mbr_bin_path(usb_disk):
 
 def set_boot_flag(usb_disk):
     if platform.system() == "Linux":
-        log("\nChecking boot flag on " + usb_disk[:-1], '\n')
-        cmd_out = subprocess.check_output("parted -m -s " + usb_disk[:-1] + " print", shell=True)
+        log("\nChecking boot flag on " + physical_disk(usb_disk), '\n')
+        cmd_out = subprocess.check_output("parted -m -s " + physical_disk(usb_disk) + " print", shell=True)
         if gpt_part_table(usb_disk) is False:
             if b'boot' in cmd_out:
-                log("\nDisk " + usb_disk[:-1] + " already has boot flag.\n")
+                log("\nDisk " + physical_disk(usb_disk) + " already has boot flag.\n")
                 return True
             else:
-                log("\nExecuting ==>  parted " + usb_disk[:-1] + " set 1 boot on", '\n')
-                if subprocess.call("parted " + usb_disk[:-1] + " set 1 boot on", shell=True) == 0:
-                    log("\nBoot flag set to bootable " + usb_disk[:-1], '\n')
+                log("\nExecuting ==>  parted " + physical_disk(usb_disk) + " set 1 boot on", '\n')
+                if subprocess.call("parted " + physical_disk(usb_disk) + " set 1 boot on", shell=True) == 0:
+                    log("\nBoot flag set to bootable " + physical_disk(usb_disk), '\n')
                     return True
                 else:
-                    log("\nUnable to set boot flag on  " + usb_disk[:-1], '\n')
+                    log("\nUnable to set boot flag on  " + physical_disk(usb_disk), '\n')
                     return False
         elif gpt_part_table(usb_disk) is True:
             if b'legacy_boot' in cmd_out:
-                log("\nGPT Disk " + usb_disk[:-1] + " already has legacy_boot flag.\n")
+                log("\nGPT Disk " + physical_disk(usb_disk) + " already has legacy_boot flag.\n")
                 return True
             else:
-                log("\nExecuting ==>  parted " + usb_disk[:-1] + " set 1 legacy_boot on", '\n')
-                if subprocess.call("parted " + usb_disk[:-1] + " set 1 legacy_boot on", shell=True) == 0:
-                    log("\nBoot flag set to legacy_boot " + usb_disk[:-1], '\n')
+                log("\nExecuting ==>  parted " + physical_disk(usb_disk) + " set 1 legacy_boot on", '\n')
+                if subprocess.call("parted " + physical_disk(usb_disk) + " set 1 legacy_boot on", shell=True) == 0:
+                    log("\nBoot flag set to legacy_boot " + physical_disk(usb_disk), '\n')
                     return True
                 else:
-                    log("\nUnable to set legacy_boot flag on  " + usb_disk[:-1], '\n')
+                    log("\nUnable to set legacy_boot flag on  " + physical_disk(usb_disk), '\n')
                     return False
 
 def linux_install_default_bootsector(usb_disk, mbr_install_cmd):
@@ -124,7 +124,7 @@ def linux_install_default_bootsector(usb_disk, mbr_install_cmd):
 
 
 def create_syslinux_bs(usb_disk, usb_mount):
-    osdriver.run_dd(osdriver.physical_disk(usb_disk),
+    osdriver.run_dd(physical_disk(usb_disk),
                     os.path.join(usb_mount, 'multibootusb', 'syslinux.bin'),
                     512, 1)
 
@@ -141,7 +141,7 @@ def syslinux_default(usb_disk):
     mbr_bin = get_mbr_bin_path(usb_disk)
     if platform.system() == 'Linux':
         mbr_install_cmd = 'dd bs=440 count=1 conv=notrunc if=' + mbr_bin \
-                          + ' of=' + usb_disk[:-1]
+                          + ' of=' + physical_disk(usb_disk)
     else:
         win_usb_disk_no = get_physical_disk_number(usb_disk)
         _windd = resource_path(os.path.join("data", "tools", "dd", "dd.exe"))

--- a/scripts/usb.py
+++ b/scripts/usb.py
@@ -187,13 +187,6 @@ def list_devices(fixed=False):
         return None
 
 
-def parent_partition(partition):
-    exploded = [c for c in partition]
-    while exploded[-1].isdigit():
-        exploded.pop()
-    return ''.join(exploded)
-
-
 def details_udev(usb_disk_part):
     """
     Get details of USB partition using udev
@@ -216,7 +209,7 @@ def details_udev(usb_disk_part):
         return None
 
     try:
-        ppart = parent_partition(usb_disk_part)
+        ppart = gen.physical_disk(usb_disk_part)
         fdisk_cmd_out = subprocess.check_output(
             'LANG=C fdisk -l ' + ppart, shell=True)
         partition_prefix = bytes(usb_disk_part, 'utf-8') + b' '
@@ -414,7 +407,7 @@ class UnmountedContext:
         self.usb_disk = usb_disk
         self.exit_callback = exit_callback
         self.is_relevant = platform.system() != 'Windows' and \
-          self.usb_disk[-1:].isdigit()
+          gen.is_partition(self.usb_disk)
 
     def assert_no_access(self):
         p = subprocess.Popen(['lsof', self.usb_disk],


### PR DESCRIPTION
This implements better handling of device node paths, removing the errors when selecting "all drives" while there are loop devices or disks with >9 partitions and making it possible to install iso's to those devices. I tested this on Linux and Windows without any errors.