### PR TITLE
fix_desktop_image_in_thema_callback ignore utf-8 errors (fix for debi…

### DIFF
--- a/scripts/update_cfg_file.py
+++ b/scripts/update_cfg_file.py
@@ -353,7 +353,7 @@ def update_distro_cfg_files(iso_link, usb_disk, distro, persistence=0):
             return
         theme_file = os.path.join(dir_, fname)
         updated = False
-        with open(theme_file, 'r', encoding='utf-8') as f:
+        with open(theme_file, 'r', encoding='utf-8', errors='replace') as f:
             pattern = re.compile(r'^desktop-image\s*:\s*(.*)$')
             try:
                 src_lines = f.readlines()


### PR DESCRIPTION
…an installation crash)

/mnt/multibootusb/debian/doc/constitution.txt
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/scripts/mbusb_gui.py", line 352, in install_syslinux
    config.distro, config.persistence)
  File "/usr/lib/python3/dist-packages/scripts/update_cfg_file.py", line 403, in update_distro_cfg_files
    callback(dirpath, f)
  File "/usr/lib/python3/dist-packages/scripts/update_cfg_file.py", line 375, in fix_desktop_image_in_thema_callback
    for line in f.readlines():
  File "/usr/lib/python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa7 in position 3408: invalid start byte
 ^C^CTraceback (most recent call last):
  File "/usr/lib/python3/dist-packages/scripts/mbusb_gui.py", line 722, in closeEvent
    def closeEvent(self, event):
KeyboardInterrupt