### PR TITLE
Fix Mageia support.

### DIFF
--- a/scripts/grub.py
+++ b/scripts/grub.py
@@ -55,7 +55,7 @@ def mbusb_update_grub_cfg():
             (loopback_cfg_list, lambda x: 'efi' in x.lower()),
             (loopback_cfg_list, lambda x: 'boot' in x.lower()),
             (grub_cfg_list, lambda x: 'efi' in x.lower()),
-            (grub_cfg_list, lambda x: 'boot' in x.lower()),
+            (grub_cfg_list, lambda x: 'boot' in x.lower() and 'efi' not in x.lower()),
             (loopback_cfg_list,
              lambda x: 'efi' not in x.lower() and 'boot' not in x.lower()),
             (grub_cfg_list,
@@ -66,7 +66,9 @@ def mbusb_update_grub_cfg():
             # We could 'break' here but will let the iteration continue
             # in order to lower the chance of keeping latent bugs.
 
-    if 0<len(candidates):
+    if config.distro == 'mageialive' and 1<len(candidates):
+        grub_cfg_path = candidates[1].replace('\\', '/')
+    elif 0<len(candidates):
         grub_cfg_path = candidates[0].replace('\\', '/')
     else :
         # No suitable grub configuration file is provided by distro.

--- a/scripts/update_cfg_file.py
+++ b/scripts/update_cfg_file.py
@@ -313,7 +313,8 @@ def update_distro_cfg_files(iso_link, usb_disk, distro, persistence=0):
                                     'from=/multibootusb/' + iso_basename(iso_link) + '/' + iso_name(iso_link) + ' initrd=',
                                     string)
                 elif distro == "mageialive":
-                    string = re.sub(r'LABEL=\S*', 'LABEL=' + usb_label, string)
+                    string = re.sub(r'LABEL=\S*', 'UUID=' + usb_uuid + ' mgalive.basedir=/multibootusb/' + iso_basename(iso_link),
+                                    string)
                 elif distro == "solydx":
                     string = re.sub(r'live-media-path=', 'live-media-path=/multibootusb/' + iso_basename(iso_link),
                                     string)


### PR DESCRIPTION
Works cleanly with Mageia 7, which no longer uses isolinux. Mageia 6.1
can be booted using grub2, albeit only with a text menu, but syslinux
boot is still broken.