### PR TITLE
Fix issue #459 and #439

### DIFF
--- a/data/multibootusb/grub/win.cfg
+++ b/data/multibootusb/grub/win.cfg
@@ -34,14 +34,14 @@ if [ ${grub_platform} == "efi" ]; then
 		}
 	fi
 
-	if [ -e /bootmgr.efi ]; then
-		menuentry "Microsoft Windows Vista/7/8/8.1 UEFI Boot (bootmgr.efi)" {
+	if [ -e /EFI/BOOT_WINDOWS/bootx64.efi ]; then
+		menuentry "Microsoft Windows Vista/7/8/8.1 UEFI Boot (bootx64.efi)" {
 			insmod part_gpt
 			insmod fat
 			insmod search_fs_uuid
 			insmod chain
 			# search --fs-uuid --set=root $hints_string $fs_uuid
-			chainloader /bootmgr.efi
+			chainloader /EFI/BOOT_WINDOWS/bootx64.efi
 		}
 	fi
 

--- a/scripts/distro.py
+++ b/scripts/distro.py
@@ -212,7 +212,12 @@ def detect_iso_from_file_list(iso_file_list):
 
     filenames = [f.lower() for f in iso_file_list]
     for keys, distro in keys_to_distro:
-        if all(k in filenames for k in keys):
+        match = True
+        for k in keys:
+            if all(k not in fn for fn in filenames):
+                match = False
+                break
+        if match is True:
             return distro
     #log("Examined %d %s in the iso but could not determine the distro."
     #  % (len(filenames), len(filenames)==1 and 'filename' or 'filenames'))

--- a/scripts/update_cfg_file.py
+++ b/scripts/update_cfg_file.py
@@ -412,7 +412,13 @@ def update_distro_cfg_files(iso_link, usb_disk, distro, persistence=0):
         shutil.copy2(resource_path(os.path.join("data", "EFI", "BOOT", "bootx64.efi")),
                                    os.path.join(config.usb_mount, 'EFI', 'BOOT'))
     elif gen.grub_efi_exist(efi_grub_img) is False:
-        gen.log('EFI image overwritten by distro install. Replacing it now...')
+        if distro == "Windows":
+            gen.log('EFI image overwritten by Windows install. Moving it now...')
+            dst = os.path.join(config.usb_mount, 'EFI', 'BOOT_WINDOWS')
+            os.makedirs(dst)
+            shutil.move(efi_grub_img, dst)
+        else:
+            gen.log('EFI image overwritten by distro install. Replacing it now...')
         shutil.copy2(resource_path(os.path.join("data", "EFI", "BOOT", "bootx64.efi")),
                      os.path.join(config.usb_mount, 'EFI', 'BOOT'))
     else:


### PR DESCRIPTION
Fix detection of Windows ISO.
Fix Windows boot in UEFI mode: boot to Windows from grub by chainloading Windows ISO's bootx64.efi instead of bootmgr.efi.