### PR TITLE
add support for ubuntu live-server isos on grub2 (tested & working)

### DIFF
--- a/data/multibootusb/grub/menus/ubuntu.d/live-server-generic.cfg
+++ b/data/multibootusb/grub/menus/ubuntu.d/live-server-generic.cfg
@@ -1,0 +1,14 @@
+for isofile in $isopath/ubuntu-*-live-server-*.iso; do
+  if [ -e "$isofile" ]; then
+    regexp --set=isoname "$isopath/(.*)" "$isofile"
+    submenu "$isoname (loopback.cfg) ->" "$isofile" {
+      iso_path="$2"
+      export iso_path
+      search --set=root --file "$iso_path"
+      loopback loop "$iso_path"
+      root=(loop)
+      configfile /boot/grub/loopback.cfg
+      loopback --delete loop
+    }
+  fi
+done


### PR DESCRIPTION
confirmed working for 18.04 and 20.04