### PR TITLE
add support for proxmox isos on grub2 (wip)

### DIFF
--- a/data/multibootusb/grub/menus/backup-server-generic.cfg
+++ b/data/multibootusb/grub/menus/backup-server-generic.cfg
@@ -1,0 +1,14 @@
+for isofile in $isopath/proxmox-backup-server_*.iso; do
+  if [ -e "$isofile" ]; then
+    regexp --set=isoname "$isopath/(.*)" "$isofile"
+    submenu "$isoname (grub.cfg) ->" "$isofile" {
+      iso_path="$2"
+      export iso_path
+      search --set=root --file "$iso_path"
+      loopback loop "$iso_path"
+      root=(loop)
+      configfile /boot/grub/grub.cfg
+      loopback --delete loop
+    }
+  fi
+done

--- a/data/multibootusb/grub/menus/mailgateway-generic.cfg
+++ b/data/multibootusb/grub/menus/mailgateway-generic.cfg
@@ -1,0 +1,14 @@
+for isofile in $isopath/proxmox-mailgateway_*.iso; do
+  if [ -e "$isofile" ]; then
+    regexp --set=isoname "$isopath/(.*)" "$isofile"
+    submenu "$isoname (grub.cfg) ->" "$isofile" {
+      iso_path="$2"
+      export iso_path
+      search --set=root --file "$iso_path"
+      loopback loop "$iso_path"
+      root=(loop)
+      configfile /boot/grub/grub.cfg
+      loopback --delete loop
+    }
+  fi
+done

--- a/data/multibootusb/grub/menus/proxmox-ve-generic.cfg
+++ b/data/multibootusb/grub/menus/proxmox-ve-generic.cfg
@@ -1,0 +1,14 @@
+for isofile in $isopath/proxmox-ve_*.iso; do
+  if [ -e "$isofile" ]; then
+    regexp --set=isoname "$isopath/(.*)" "$isofile"
+    submenu "$isoname (grub.cfg) ->" "$isofile" {
+      iso_path="$2"
+      export iso_path
+      search --set=root --file "$iso_path"
+      loopback loop "$iso_path"
+      root=(loop)
+      configfile /boot/grub/grub.cfg
+      loopback --delete loop
+    }
+  fi
+done


### PR DESCRIPTION
currently fails loading kernel/initrd, as it tries reading from the wrong device

also tried with no success:
```
for isofile in $isopath/proxmox-ve_*.iso; do
  if [ -e "$isofile" ]; then
    regexp --set=isoname "$isopath/(.*)" "$isofile"
    submenu "$isoname ->" "$isofile" {
      iso_path="$2"
      insmod regexp
      loopback loop "$iso_path"
      root=(loop)
      menuentry "Install Proxmox VE" {
        bootoptions="findiso=$iso_path ro ramdisk_size=16777216 rw quiet splash=silent"
        linux /boot/linux26 $bootoptions
        initrd /boot/initrd.img
      }
    }
  fi
done
```
seems to be a bug but i dont have deep knowledge at this point to be sure  
https://forum.proxmox.com/threads/unable-to-install-no-cdrom-found.42043/page-2