### PR TITLE
add support for openmediavault isos on grub2 (wip)

### DIFF
--- a/data/multibootusb/grub/menus/openmediavault.d/install-generic.cfg
+++ b/data/multibootusb/grub/menus/openmediavault.d/install-generic.cfg
@@ -1,0 +1,14 @@
+for isofile in $isopath/openmediavault_*.iso; do
+  if [ -e "$isofile" ]; then
+    regexp --set=isoname "$isopath/(.*)" "$isofile"
+    submenu "$isoname (grub.cfg) ->" "$isofile" {
+      iso_path="$2"
+      export iso_path
+      search --set=root --file "$iso_path"
+      loopback loop "$iso_path"
+      root=(loop)
+      configfile /boot/grub/grub.cfg
+      loopback --delete loop
+    }
+  fi
+done


### PR DESCRIPTION
currently broken

during install, wont "mount cdrom"